### PR TITLE
Add PR template and branch naming convention

### DIFF
--- a/.github/BRANCH_NAMING.md
+++ b/.github/BRANCH_NAMING.md
@@ -1,0 +1,31 @@
+# Branch naming
+
+```
+<type>/<short-description>
+```
+
+**Types:** `feat` · `fix` · `test` · `task` · `chore` · `docs` · `refactor`
+
+Use lowercase kebab-case after the slash. Keep it short and specific.
+
+| Type | When |
+|------|------|
+| `feat` | New feature or user-visible behavior |
+| `fix` | Bug fix |
+| `test` | Tests only |
+| `task` | Planned work (multi-step, not a single bug/feature) |
+| `chore` | CI, deps, config |
+| `docs` | Documentation only |
+| `refactor` | Code change, same behavior |
+
+**Examples**
+
+```
+feat/custom-tools-ui
+fix/contact-pagination
+test/custom-tools-e2e
+task/pr-template
+chore/ci-branch-check
+```
+
+CI rejects PRs whose branch name does not match (bots excepted).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+Branch: `<type>/<short-description>` — see [branch naming](.github/BRANCH_NAMING.md) (`feat`, `fix`, `test`, `task`, …)
+
+## What & why
+
+<!-- 1–2 sentences -->
+
+## Checklist
+
+- [ ] **User impact:** none / describe: 
+- [ ] **Migration:** none / added (`database/migrations/`) — notes: 
+- [ ] **Tests:** none / unit-integration / e2e — what: 
+- [ ] **README:** updated / N/A
+
+## How to verify
+
+1. 
+2. 
+
+<!-- UI change? Add screenshot. Deploy steps? Add one line here. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,24 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Validate branch name
+        if: github.event_name == 'pull_request'
+        run: |
+          branch="${{ github.head_ref }}"
+          if [[ "$branch" =~ ^(dependabot|renovate)/ ]]; then
+            echo "Skipping branch name check for bot branch: $branch"
+            exit 0
+          fi
+          pattern='^(feat|fix|test|task|chore|docs|refactor)/[a-z0-9]+(-[a-z0-9]+)*$'
+          if [[ "$branch" =~ $pattern ]]; then
+            echo "Branch name OK: $branch"
+            exit 0
+          fi
+          echo "::error::Branch name must be <type>/<short-description> (see .github/BRANCH_NAMING.md)"
+          echo "Allowed types: feat, fix, test, task, chore, docs, refactor"
+          echo "Example: feat/agent-inline-save"
+          exit 1
+
       - name: Disallow skipped or todo tests
         run: |
           if grep -rE 'it\.todo|test\.skip' backend/src frontend/src whatsapp/src --include='*.test.*'; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,16 @@ npm run build          # backend + frontend
 
 Run the stack: see root `README.md` (`docker compose up -d`).
 
+## Pull requests
+
+**Branch names** (enforced in CI): `<type>/<short-description>` in lowercase kebab-case.
+
+Types: `feat` · `fix` · `test` · `task` · `chore` · `docs` · `refactor` — see **`.github/BRANCH_NAMING.md`**.
+
+Examples: `feat/custom-tools-ui`, `fix/contact-pagination`, `test/custom-tools-e2e`.
+
+When creating a PR, fill out **`.github/pull_request_template.md`**: what & why, user impact, migrations, tests, README, and how to verify.
+
 ## Stack
 
 | Layer | Technology |


### PR DESCRIPTION
Branch: `chore/pr-branch-templates`

## What & why

Adds a short GitHub PR template and a branch naming convention (`feat/`, `fix/`, `test/`, etc.) enforced in CI so every PR starts with consistent context.

## Checklist

- [x] **User impact:** none
- [x] **Migration:** none
- [x] **Tests:** none — docs/CI only
- [x] **README:** N/A

## How to verify

1. Open a new PR and confirm the template pre-fills the description.
2. Confirm CI passes on this PR (branch name `chore/pr-branch-templates` matches the pattern).
3. Optionally open a PR from a badly named branch and confirm the hygiene job fails.


Made with [Cursor](https://cursor.com)