### PR TITLE
chore: add explanatory comments to all test cases

### DIFF
--- a/backend/src/agent/session.test.ts
+++ b/backend/src/agent/session.test.ts
@@ -24,6 +24,8 @@ beforeEach(() => {
 });
 
 describe("resolveSessionId", () => {
+  // Creates a new conversation then a new session when no sessionId is provided.
+  // Expected: returns the new session ID and calls both creation repos.
   it("creates new session when none exists", async () => {
     createAgentConversationMock.mockResolvedValue("conv-1");
     createAgentSessionMock.mockResolvedValue({ id: "sess-1" } as never);
@@ -42,6 +44,8 @@ describe("resolveSessionId", () => {
     });
   });
 
+  // Skips creating new resources when an existing sessionId is found in the DB.
+  // Expected: returns the existing session ID; no conversation/session creation.
   it("reuses existing session when sessionId provided and found", async () => {
     findAgentSessionMock.mockResolvedValue({ id: "existing-sess" } as never);
 
@@ -52,6 +56,8 @@ describe("resolveSessionId", () => {
     expect(createAgentConversationMock).not.toHaveBeenCalled();
   });
 
+  // In dry-run mode no DB writes should happen; a synthetic UUID is returned.
+  // Expected: result is a 36-char UUID string, no repo calls made.
   it("skips DB writes in dry-run mode", async () => {
     const result = await resolveSessionId("ws-1", true);
 
@@ -62,6 +68,8 @@ describe("resolveSessionId", () => {
     expect(findAgentSessionMock).not.toHaveBeenCalled();
   });
 
+  // If conversation creation fails (returns null), the whole flow should abort.
+  // Expected: returns null and does not attempt to create a session.
   it("returns null when createAgentConversation fails", async () => {
     createAgentConversationMock.mockResolvedValue(null);
 

--- a/backend/src/agent/system-prompt.test.ts
+++ b/backend/src/agent/system-prompt.test.ts
@@ -6,6 +6,8 @@ import {
 } from "./system-prompt.js";
 
 describe("DEFAULT_TOOL_KEYS", () => {
+  // Verifies the default tool set contains all essential agent capabilities.
+  // Expected: the array includes create_task, load_skills, send_whatsapp_message, handoff_to_human, apply_conversation_labels.
   it("includes all required default tools", () => {
     expect(DEFAULT_TOOL_KEYS).toContain("create_task");
     expect(DEFAULT_TOOL_KEYS).toContain("load_skills");
@@ -16,6 +18,8 @@ describe("DEFAULT_TOOL_KEYS", () => {
 });
 
 describe("resolveEnabledToolKeys", () => {
+  // Merges default and config-provided tools without duplicates.
+  // Expected: output contains both default and extra keys; duplicates appear only once.
   it("returns default tools plus config tools, deduplicated", () => {
     const result = resolveEnabledToolKeys(["get_weather", "create_task"]);
     expect(result).toContain("create_task");
@@ -26,11 +30,15 @@ describe("resolveEnabledToolKeys", () => {
     expect(result.filter((k) => k === "create_task")).toHaveLength(1);
   });
 
+  // When configTools is undefined, only the default tool keys should be returned.
+  // Expected: result equals DEFAULT_TOOL_KEYS.
   it("returns only defaults when configTools is undefined", () => {
     const result = resolveEnabledToolKeys(undefined);
     expect(result).toEqual([...DEFAULT_TOOL_KEYS]);
   });
 
+  // When configTools is an empty array, only the default tool keys should be returned.
+  // Expected: result equals DEFAULT_TOOL_KEYS.
   it("returns only defaults when configTools is empty array", () => {
     const result = resolveEnabledToolKeys([]);
     expect(result).toEqual([...DEFAULT_TOOL_KEYS]);
@@ -51,6 +59,8 @@ const baseInput = {
 };
 
 describe("buildAgentSystemPrompt", () => {
+  // Assembles all configuration sections into a single system prompt string.
+  // Expected: prompt contains profile name, behavior, context, templates, handoff topics, and labels.
   it("merges behaviour, response templates, context groups, handoff topics, and skills", () => {
     const prompt = buildAgentSystemPrompt(baseInput);
     expect(prompt).toContain("WidgetBot");
@@ -61,6 +71,8 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("VIP, New Lead");
   });
 
+  // When dryRun is true, the prompt must instruct the agent not to send real WhatsApp messages.
+  // Expected: dry-run rule is present; live message rule is absent.
   it("includes dry-run WhatsApp rule when dryRun is true", () => {
     const prompt = buildAgentSystemPrompt({ ...baseInput, dryRun: true });
     expect(prompt).toContain(
@@ -71,6 +83,8 @@ describe("buildAgentSystemPrompt", () => {
     );
   });
 
+  // When dryRun is false, the prompt must instruct the agent to send live WhatsApp messages.
+  // Expected: live message rule is present; dry-run rule is absent.
   it("includes live WhatsApp rule when dryRun is false", () => {
     const prompt = buildAgentSystemPrompt({ ...baseInput, dryRun: false });
     expect(prompt).toContain(
@@ -81,11 +95,15 @@ describe("buildAgentSystemPrompt", () => {
     );
   });
 
+  // When no asset groups are configured, the prompt should indicate that clearly.
+  // Expected: prompt contains "(none configured for this agent)".
   it('shows "(none configured)" for empty asset groups', () => {
     const prompt = buildAgentSystemPrompt(baseInput);
     expect(prompt).toContain("(none configured for this agent)");
   });
 
+  // The available tools section lists enabled tool keys with their descriptions.
+  // Expected: prompt lists the tool keys and the custom tool description.
   it("includes available tools section with all enabled tool keys", () => {
     const prompt = buildAgentSystemPrompt({
       ...baseInput,

--- a/backend/src/agent/tools/index.test.ts
+++ b/backend/src/agent/tools/index.test.ts
@@ -39,6 +39,8 @@ const mockContext: AgentToolRuntimeContext = {
 };
 
 describe("getAgentTools", () => {
+  // All builtin and custom tool keys are resolved into tool instances in one map.
+  // Expected: 6 tools returned, including builtins and one custom key.
   it("returns builtin and custom tools when keys enabled", async () => {
     const tools = await getAgentTools(mockContext, [
       "create_task",
@@ -56,11 +58,15 @@ describe("getAgentTools", () => {
     expect(keys).toContain("load_skills");
   });
 
+  // No tools should be returned when the enabled list is empty.
+  // Expected: empty object with no keys.
   it("returns empty object when enabledToolKeys is empty", async () => {
     const tools = await getAgentTools(mockContext, []);
     expect(Object.keys(tools)).toHaveLength(0);
   });
 
+  // Non-builtin keys are loaded as custom tools alongside builtins.
+  // Expected: both the builtin key and the custom key appear in the result.
   it("loads custom tools for non-builtin keys", async () => {
     const tools = await getAgentTools(mockContext, ["create_task", "my_custom_tool"]);
     const keys = Object.keys(tools);
@@ -68,6 +74,8 @@ describe("getAgentTools", () => {
     expect(keys).toContain("my_custom_tool");
   });
 
+  // A null/undefined tool keys list should be handled gracefully without crashing.
+  // Expected: empty object returned, no error thrown.
   it("returns empty object when enabledToolKeys is not an array", async () => {
     const tools = await getAgentTools(mockContext, null as unknown as string[]);
     expect(Object.keys(tools)).toHaveLength(0);

--- a/backend/src/lib/api-keys.test.ts
+++ b/backend/src/lib/api-keys.test.ts
@@ -7,6 +7,8 @@ vi.mock("./env.js", () => ({
 const { generateApiKeyMaterial, hashApiKey, getApiKeyVerificationHashes } = await import("./api-keys.js");
 
 describe("generateApiKeyMaterial", () => {
+  // Generates a fresh API key with the expected prefix, non-empty raw key, hash, and prefix.
+  // Expected: rawKey starts with "sk_senqo_", all fields are non-empty, prefix is first 12 chars.
   it("returns rawKey, keyPrefix, keyHash as non-empty strings", () => {
     const result = generateApiKeyMaterial();
     expect(result.rawKey.length).toBeGreaterThan(0);
@@ -18,6 +20,8 @@ describe("generateApiKeyMaterial", () => {
 });
 
 describe("hashApiKey", () => {
+  // The hash function must be deterministic — same key should produce identical hashes.
+  // Expected: two calls with the same raw key return the exact same hash string.
   it("is deterministic (same input = same output)", () => {
     const key = "sk_senqo_deadbeefcafebabe1234567890abcdef";
     const h1 = hashApiKey(key);
@@ -27,6 +31,8 @@ describe("hashApiKey", () => {
 });
 
 describe("getApiKeyVerificationHashes", () => {
+  // Returns an array of hashes for verification, including current and legacy hash methods.
+  // Expected: at least 2 hashes; the first entry matches the current hashApiKey output.
   it("returns array with current hash plus legacy hashes", () => {
     const key = "sk_senqo_testkey1234567890abcdef123456";
     const hashes = getApiKeyVerificationHashes(key);

--- a/backend/src/lib/app-version.test.ts
+++ b/backend/src/lib/app-version.test.ts
@@ -12,12 +12,16 @@ describe("getAppVersion", () => {
     }
   });
 
+  // When APP_VERSION env var is set, the function should return that value directly.
+  // Expected: returns "1.2.3" as the version string.
   it("returns APP_VERSION when set", async () => {
     process.env.APP_VERSION = "1.2.3";
     const { getAppVersion } = await import("./app-version.js");
     expect(getAppVersion()).toBe("1.2.3");
   });
 
+  // When APP_VERSION is not set, it should fall back to reading package.json.
+  // Expected: returns the version from package.json (mocked as "0.1.0").
   it("falls back to package.json version when APP_VERSION is unset", async () => {
     delete process.env.APP_VERSION;
     const { getAppVersion } = await import("./app-version.js");

--- a/backend/src/lib/auth-cookie.test.ts
+++ b/backend/src/lib/auth-cookie.test.ts
@@ -7,18 +7,24 @@ afterEach(() => {
 
 describe("auth-cookie", () => {
   describe("isAuthCookieSecure", () => {
+    // An https APP_URL without override should yield a secure cookie flag.
+    // Expected: returns true for https URL when no AUTH_COOKIE_SECURE override.
     it("returns true for https URL when env override not set", async () => {
       const { isAuthCookieSecure } = await import("../lib/auth-cookie.js");
       process.env.APP_URL = "https://app.example.com";
       expect(isAuthCookieSecure()).toBe(true);
     });
 
+    // An http APP_URL without override should not use secure cookies.
+    // Expected: returns false because the URL scheme is not https.
     it("returns false for http URL when env override not set", async () => {
       const { isAuthCookieSecure } = await import("../lib/auth-cookie.js");
       process.env.APP_URL = "http://localhost:3000";
       expect(isAuthCookieSecure()).toBe(false);
     });
 
+    // Override flag "true" forces secure cookies even when the URL is http.
+    // Expected: returns true regardless of the URL being http.
     it("returns true when AUTH_COOKIE_SECURE override is true", async () => {
       const { isAuthCookieSecure } = await import("../lib/auth-cookie.js");
       process.env.AUTH_COOKIE_SECURE = "true";
@@ -26,6 +32,8 @@ describe("auth-cookie", () => {
       expect(isAuthCookieSecure()).toBe(true);
     });
 
+    // Override flag "false" disables secure cookies even when the URL is https.
+    // Expected: returns false regardless of the URL being https.
     it("returns false when AUTH_COOKIE_SECURE override is false", async () => {
       const { isAuthCookieSecure } = await import("../lib/auth-cookie.js");
       process.env.AUTH_COOKIE_SECURE = "false";
@@ -33,6 +41,8 @@ describe("auth-cookie", () => {
       expect(isAuthCookieSecure()).toBe(false);
     });
 
+    // An empty APP_URL with no override should default to non-secure.
+    // Expected: returns false as a safe default.
     it("returns false when APP_URL is empty and no override", async () => {
       const { isAuthCookieSecure } = await import("../lib/auth-cookie.js");
       process.env.APP_URL = "";
@@ -41,6 +51,8 @@ describe("auth-cookie", () => {
   });
 
   describe("refreshCookieOptions", () => {
+    // Refresh cookie options must be httpOnly, match the secure setting, and have 7-day expiry.
+    // Expected: httpOnly=true, secure=true, sameSite=lax, path="/api/auth", maxAge=7 days in seconds.
     it("returns httpOnly:true cookie options with 7-day maxAge", async () => {
       process.env.APP_URL = "https://app.example.com";
       const { refreshCookieOptions } = await import("../lib/auth-cookie.js");

--- a/backend/src/lib/auth-jwt-secret-missing.test.ts
+++ b/backend/src/lib/auth-jwt-secret-missing.test.ts
@@ -5,6 +5,8 @@ afterEach(() => {
 });
 
 describe("auth-jwt edge cases", () => {
+  // Signing a token without JWT_SECRET set should throw a descriptive error.
+  // Expected: rejects with error message "JWT_SECRET environment variable is not set".
   it("throws when JWT_SECRET is not set", async () => {
     const { signAccessToken } = await import("../lib/auth-jwt.js");
     await expect(signAccessToken("user-1")).rejects.toThrow("JWT_SECRET environment variable is not set");

--- a/backend/src/lib/auth-jwt.test.ts
+++ b/backend/src/lib/auth-jwt.test.ts
@@ -12,6 +12,8 @@ afterAll(() => {
 
 describe("auth-jwt", () => {
   describe("signAccessToken", () => {
+    // Access token must be a valid JWT containing the user sub and verifiable.
+    // Expected: verifyToken returns non-null with userId matching the signed sub.
     it("returns a valid JWT with sub and 15-min expiry", async () => {
       const { signAccessToken, verifyToken } = await import("../lib/auth-jwt.js");
       const token = await signAccessToken("user-1");
@@ -22,6 +24,8 @@ describe("auth-jwt", () => {
   });
 
   describe("signRefreshToken", () => {
+    // Refresh token must be verifiable by verifyRefreshToken and contain the user sub.
+    // Expected: verifyRefreshToken returns non-null with the correct userId.
     it("returns a valid JWT with type: refresh and 7-day expiry", async () => {
       const { signRefreshToken, verifyRefreshToken } = await import("../lib/auth-jwt.js");
       const token = await signRefreshToken("user-1");
@@ -32,6 +36,8 @@ describe("auth-jwt", () => {
   });
 
   describe("verifyToken", () => {
+    // A valid access token must decode to the correct userId.
+    // Expected: returns { userId: "user-1" }.
     it("returns userId for a valid access token", async () => {
       const { signAccessToken, verifyToken } = await import("../lib/auth-jwt.js");
       const token = await signAccessToken("user-1");
@@ -39,12 +45,16 @@ describe("auth-jwt", () => {
       expect(result).toEqual({ userId: "user-1" });
     });
 
+    // An empty string token is never valid and should not throw.
+    // Expected: returns null.
     it("returns null for an empty token", async () => {
       const { verifyToken } = await import("../lib/auth-jwt.js");
       const result = await verifyToken("");
       expect(result).toBeNull();
     });
 
+    // Tampering with a valid token should cause verification to fail.
+    // Expected: returns null for a token with the last 5 chars replaced.
     it("returns null for a tampered token", async () => {
       const { signAccessToken, verifyToken } = await import("../lib/auth-jwt.js");
       const token = await signAccessToken("user-1");
@@ -53,6 +63,8 @@ describe("auth-jwt", () => {
       expect(result).toBeNull();
     });
 
+    // An already-expired token (exp=1) must be rejected.
+    // Expected: returns null because the token expired in 1970.
     it("returns null for an already-expired token", async () => {
       const { verifyToken } = await import("../lib/auth-jwt.js");
       const expiredToken = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyLTEiLCJleHAiOjF9.BAD_SIGNATURE";
@@ -62,6 +74,8 @@ describe("auth-jwt", () => {
   });
 
   describe("verifyRefreshToken", () => {
+    // verifyRefreshToken must reject access tokens (not of type "refresh").
+    // Expected: returns null when passed an access token instead of refresh token.
     it("rejects a non-refresh-type token", async () => {
       const { signAccessToken, verifyRefreshToken } = await import("../lib/auth-jwt.js");
       const accessToken = await signAccessToken("user-1");

--- a/backend/src/lib/auth-refresh-request.test.ts
+++ b/backend/src/lib/auth-refresh-request.test.ts
@@ -23,6 +23,8 @@ beforeEach(() => {
 
 describe("auth-refresh-request", () => {
   describe("readRefreshTokenFromRequest", () => {
+    // Parses the "senqo_refresh" cookie from the request header to extract the token value.
+    // Expected: returns the token value from the cookie string.
     it("extracts refresh token from cookie header", async () => {
       const { readRefreshTokenFromRequest } = await getAuthRefreshRequest();
       const c = {
@@ -35,6 +37,8 @@ describe("auth-refresh-request", () => {
       expect(result).toBe("test-token-123");
     });
 
+    // When no cookie is present, falls back to reading refreshToken from the JSON body.
+    // Expected: returns the token from the JSON body field.
     it("extracts refresh token from JSON body when no cookie", async () => {
       const { readRefreshTokenFromRequest } = await getAuthRefreshRequest();
       const c = {
@@ -47,6 +51,8 @@ describe("auth-refresh-request", () => {
       expect(result).toBe("body-token-456");
     });
 
+    // When neither cookie nor body has a token, returns null without error.
+    // Expected: returns null.
     it("returns null when no token in cookie or body", async () => {
       const { readRefreshTokenFromRequest } = await getAuthRefreshRequest();
       const c = {

--- a/backend/src/lib/conversation-thread-events.test.ts
+++ b/backend/src/lib/conversation-thread-events.test.ts
@@ -2,12 +2,16 @@ import { describe, it, expect } from "vitest";
 import { THREAD_EVENT_HANDOFF_TO_HUMAN, THREAD_EVENT_MANUAL_TOGGLE } from "./conversation-thread-events.js";
 
 describe("THREAD_EVENT_HANDOFF_TO_HUMAN", () => {
+  // Ensures the exported constant has the exact string value expected by consumers.
+  // Expected: the constant equals the string "handoff_to_human".
   it("is the string 'handoff_to_human'", () => {
     expect(THREAD_EVENT_HANDOFF_TO_HUMAN).toBe("handoff_to_human");
   });
 });
 
 describe("THREAD_EVENT_MANUAL_TOGGLE", () => {
+  // Ensures the exported constant has the exact string value expected by consumers.
+  // Expected: the constant equals the string "manual_toggle_human".
   it("is the string 'manual_toggle_human'", () => {
     expect(THREAD_EVENT_MANUAL_TOGGLE).toBe("manual_toggle_human");
   });

--- a/backend/src/lib/infer-custom-tool-input-schema.test.ts
+++ b/backend/src/lib/infer-custom-tool-input-schema.test.ts
@@ -9,6 +9,8 @@ const executeOnly = `export async function execute(
 }`;
 
 describe("inferCustomToolInputSchema", () => {
+  // Parses the `execute` function's input type to produce a JSON Schema with required string properties.
+  // Expected: returns ok=true with an object schema containing "location" as a required string.
   it("infers required string properties from execute input type", () => {
     const result = inferCustomToolInputSchema(executeOnly);
     expect(result.ok).toBe(true);
@@ -21,6 +23,8 @@ describe("inferCustomToolInputSchema", () => {
     });
   });
 
+  // Legacy exports (description, requiredEnv, inputSchema) should not break inference.
+  // Expected: still returns ok=true, ignoring the old constants.
   it("ignores legacy exports and still infers schema", () => {
     const legacy = `export const description = "old";
 export const requiredEnv = [] as const;
@@ -30,6 +34,8 @@ ${executeOnly}`;
     expect(result.ok).toBe(true);
   });
 
+  // If no `execute` export exists, inference must fail with a relevant error.
+  // Expected: returns ok=false with an error message containing "execute".
   it("returns error when execute export is missing", () => {
     const result = inferCustomToolInputSchema("export function run() {}");
     expect(result.ok).toBe(false);
@@ -37,6 +43,8 @@ ${executeOnly}`;
     expect(result.error).toContain("execute");
   });
 
+  // Mixed unions (e.g. string literal | number) are not supported and must be rejected.
+  // Expected: returns ok=false with an error message mentioning "mode".
   it("rejects mixed unions that are not all string literals", () => {
     const source = `export async function execute(
   input: { mode: "alpha" | number },
@@ -50,6 +58,8 @@ ${executeOnly}`;
     expect(result.error).toContain("mode");
   });
 
+  // String literal unions should be inferred as JSON Schema enum properties.
+  // Expected: returns ok=true with mode as a string enum and count as an optional number.
   it("infers string literal unions as enum properties", () => {
     const source = `export async function execute(
   input: { mode: "alpha" | "beta", count?: number },

--- a/backend/src/lib/json-schema-to-zod.test.ts
+++ b/backend/src/lib/json-schema-to-zod.test.ts
@@ -11,6 +11,8 @@ describe("jsonSchemaToZod → validates string enum properties", () => {
     required: ["mode"],
   });
 
+  // Values listed in the enum must parse successfully.
+  // Expected: schema.parse accepts both "alpha" and "beta" (with optional count).
   it("accepts allowed enum values", () => {
     expect(schema.parse({ mode: "alpha" })).toEqual({ mode: "alpha" });
     expect(schema.parse({ mode: "beta", count: 10 })).toEqual({
@@ -19,6 +21,8 @@ describe("jsonSchemaToZod → validates string enum properties", () => {
     });
   });
 
+  // Values not in the enum must throw a Zod validation error.
+  // Expected: schema.parse throws when mode is "gamma".
   it("rejects values outside the enum", () => {
     expect(() => schema.parse({ mode: "gamma" })).toThrow();
   });

--- a/backend/src/lib/pagination.test.ts
+++ b/backend/src/lib/pagination.test.ts
@@ -3,42 +3,58 @@ import { listPageOffset, parseListPageParams } from "../lib/pagination.js";
 
 describe("pagination", () => {
   describe("listPageOffset", () => {
+    // Page 1 with pageSize 10 should start at offset 0.
+    // Expected: returns 0.
     it("returns 0 for page 1 with pageSize 10", () => {
       expect(listPageOffset(1, 10)).toBe(0);
     });
 
+    // Page 2 with pageSize 10 should skip the first 10 items.
+    // Expected: returns 10.
     it("returns 10 for page 2 with pageSize 10", () => {
       expect(listPageOffset(2, 10)).toBe(10);
     });
 
+    // Page 3 with pageSize 25 should skip the first 50 items (3-1)*25.
+    // Expected: returns 50.
     it("returns 50 for page 3 with pageSize 25", () => {
       expect(listPageOffset(3, 25)).toBe(50);
     });
   });
 
   describe("parseListPageParams", () => {
+    // When no query params are provided, sensible defaults must be used.
+    // Expected: page=1, pageSize=10.
     it("returns defaults when no params are provided", () => {
       const result = parseListPageParams(undefined, undefined);
       expect(result.page).toBe(1);
       expect(result.pageSize).toBe(10);
     });
 
+    // Valid numeric strings should be parsed to their integer values.
+    // Expected: page=3, pageSize=20.
     it("parses valid page and pageSize", () => {
       const result = parseListPageParams("3", "20");
       expect(result.page).toBe(3);
       expect(result.pageSize).toBe(20);
     });
 
+    // pageSize above the maximum allowed must be clamped down.
+    // Expected: pageSize is clamped to 50 (MAX_LIST_PAGE_SIZE).
     it("clamps pageSize to MAX_LIST_PAGE_SIZE (50)", () => {
       const result = parseListPageParams("1", "100");
       expect(result.pageSize).toBe(50);
     });
 
+    // Non-numeric page values should fall back to 1 instead of NaN.
+    // Expected: page defaults to 1.
     it("defaults invalid page to 1", () => {
       const result = parseListPageParams("abc", "10");
       expect(result.page).toBe(1);
     });
 
+    // Non-numeric pageSize should fall back to the provided defaultPageSize.
+    // Expected: pageSize=15 (the custom default) when input is "abc".
     it("defaults invalid pageSize to defaultPageSize", () => {
       const result = parseListPageParams("2", "abc", 15);
       expect(result.pageSize).toBe(15);

--- a/backend/src/lib/realtime-bus.test.ts
+++ b/backend/src/lib/realtime-bus.test.ts
@@ -3,6 +3,8 @@ import { EventEmitter } from "node:events";
 import { publish, subscribe } from "./realtime-bus.js";
 
 describe("publish", () => {
+  // Publishing to a workspace channel should deliver the event to subscribers of that workspace.
+  // Expected: the subscriber spy is called with the published event payload.
   it("emits to workspace-specific channel", () => {
     const spy = vi.fn();
     const unsubscribe = subscribe("ws-1", spy);
@@ -11,6 +13,8 @@ describe("publish", () => {
     unsubscribe();
   });
 
+  // Publishing to an empty workspace ID should be a safe no-op — no subscribers triggered.
+  // Expected: no error thrown.
   it("no-op when workspaceId is empty", () => {
     publish("", { type: "message.created", conversationId: "conv-1" });
     // should not throw
@@ -18,6 +22,8 @@ describe("publish", () => {
 });
 
 describe("subscribe", () => {
+  // Subscribers should only receive events for their own workspace, not cross-contaminated.
+  // Expected: spy1 called once, spy2 not called at all.
   it("receives events for matching workspace only", () => {
     const spy1 = vi.fn();
     const spy2 = vi.fn();
@@ -30,6 +36,8 @@ describe("subscribe", () => {
     unsub2();
   });
 
+  // After unsubscribing, the callback must not receive further events.
+  // Expected: spy is not called after unsubscribe.
   it("unsubscribe stops receiving events", () => {
     const spy = vi.fn();
     const unsubscribe = subscribe("ws-1", spy);

--- a/backend/src/lib/whatsapp-jid.test.ts
+++ b/backend/src/lib/whatsapp-jid.test.ts
@@ -6,18 +6,24 @@ import {
 } from "./whatsapp-jid.js";
 
 describe("isNewsletterChatJid", () => {
+  // Channel JIDs ending with @newsletter must be identified as newsletter chats.
+  // Expected: returns true for a valid channel JID.
   it("returns true for channel JIDs", () => {
     expect(isNewsletterChatJid("120363123456789012@newsletter")).toBe(true);
   });
 });
 
 describe("isIngestableDmChatJid", () => {
+  // Channel JIDs are not ingestable DM chats — they should be excluded.
+  // Expected: returns false for a @newsletter JID.
   it("returns false for channel JIDs", () => {
     expect(isIngestableDmChatJid("120363123456789012@newsletter")).toBe(false);
   });
 });
 
 describe("nonDmChatIgnoreMessage", () => {
+  // Non-DM chats (channels) should produce a specific ignore reason message.
+  // Expected: returns "ignored: channel message" for a @newsletter JID.
   it("returns channel-specific ignore text", () => {
     expect(nonDmChatIgnoreMessage("120363123456789012@newsletter")).toBe(
       "ignored: channel message",

--- a/backend/src/lib/workspace-secrets-crypto.test.ts
+++ b/backend/src/lib/workspace-secrets-crypto.test.ts
@@ -15,6 +15,8 @@ describe("workspace-secrets-crypto", () => {
     process.env.WORKSPACE_SECRETS_KEY = original;
   });
 
+  // Encrypting and then decrypting a plaintext should return the original value.
+  // Expected: decrypted value matches the input; valueHint shows the last 4 masked chars.
   it("encryptWorkspaceSecret → decryptWorkspaceSecret round-trips plaintext", () => {
     const encrypted = encryptWorkspaceSecret("super-secret-value");
     const decrypted = decryptWorkspaceSecret(encrypted);

--- a/backend/src/middleware/api-host-guard.test.ts
+++ b/backend/src/middleware/api-host-guard.test.ts
@@ -17,6 +17,7 @@ function mockContext(host: string | null, forwardedHost: string | null = null) {
 beforeEach(() => { vi.clearAllMocks(); });
 
 describe("apiHostGuardMiddleware", () => {
+  // Host matches allowed list → middleware calls next() without blocking the request, needed to ensure valid API hosts are not rejected.
   it("allows when host matches PUBLIC_API_ALLOWED_HOSTS", async () => {
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("PUBLIC_API_ALLOWED_HOSTS", "api.example.com");
@@ -26,6 +27,7 @@ describe("apiHostGuardMiddleware", () => {
     expect(next).toHaveBeenCalled();
   });
 
+  // Host is not in the allow list → middleware returns 403 and stops the request, needed to verify unauthorized hosts are blocked in production.
   it("denies (403) when host not allowed in production", async () => {
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("PUBLIC_API_ALLOWED_HOSTS", "api.example.com");

--- a/backend/src/middleware/api-key-auth.test.ts
+++ b/backend/src/middleware/api-key-auth.test.ts
@@ -16,6 +16,7 @@ function createApp() {
 beforeEach(() => { vi.clearAllMocks(); });
 
 describe("apiKeyAuthMiddleware", () => {
+  // No x-api-key header in the request → 401 is returned to reject unauthenticated access, needed to ensure the guard blocks missing credentials.
   it("returns 401 when no x-api-key header", async () => {
     const app = createApp();
     const res = await app.request("/api/test");
@@ -24,6 +25,7 @@ describe("apiKeyAuthMiddleware", () => {
     expect(body.error).toBe("invalid_api_key");
   });
 
+  // API key is sent but verifyApiKey returns ok:false → 401 is returned, needed to ensure invalid keys are rejected at the middleware boundary.
   it("returns 401 when verifyApiKey returns ok false", async () => {
     mockVerifyApiKey.mockResolvedValue({ ok: false, reason: "invalid_api_key" });
     const app = createApp();
@@ -31,6 +33,7 @@ describe("apiKeyAuthMiddleware", () => {
     expect(res.status).toBe(401);
   });
 
+  // A valid API key is verified and workspaceId is set on the context → 200 and correct workspace is returned, needed to confirm auth passes workspace context through.
   it("sets workspaceId and calls next for valid key", async () => {
     mockVerifyApiKey.mockResolvedValue({ ok: true, workspaceId: "ws-1" });
     const app = createApp();

--- a/backend/src/middleware/auth.test.ts
+++ b/backend/src/middleware/auth.test.ts
@@ -17,6 +17,7 @@ function createApp() {
 }
 
 describe("authMiddleware", () => {
+  // No Authorization header is sent → 401 Unauthorized is returned, needed to confirm the middleware blocks unauthenticated requests.
   it("returns 401 when no Bearer token is present", async () => {
     const app = createApp();
     const res = await app.request("/protected/hello");
@@ -25,6 +26,7 @@ describe("authMiddleware", () => {
     expect(body.error).toBe("Unauthorized");
   });
 
+  // An invalid Bearer token is sent (verifyToken returns null) → 401 is returned, needed to ensure malformed/expired tokens are rejected.
   it("returns 401 when token is invalid", async () => {
     verifyTokenMock.mockResolvedValue(null);
     const app = createApp();
@@ -34,6 +36,7 @@ describe("authMiddleware", () => {
     expect(res.status).toBe(401);
   });
 
+  // A valid Bearer token is verified and userId is set in context → 200 and the userId are returned to downstream handler, needed to confirm auth injects correct user identity.
   it("sets userId on context and calls next for valid token", async () => {
     verifyTokenMock.mockResolvedValue({ userId: "user-123" });
     const app = createApp();

--- a/backend/src/middleware/workspace.test.ts
+++ b/backend/src/middleware/workspace.test.ts
@@ -25,6 +25,7 @@ beforeEach(() => {
 });
 
 describe("workspaceMiddleware", () => {
+  // User is authenticated but not a member of the requested workspace → 403 is returned, needed to enforce workspace-level access control.
   it("returns 403 when user is not a workspace member", async () => {
     mockValidateWorkspaceMembership.mockResolvedValue(false);
     const app = createApp();
@@ -34,6 +35,7 @@ describe("workspaceMiddleware", () => {
     expect(res.status).toBe(403);
   });
 
+  // User is a valid workspace member → workspaceId is set on context and request proceeds with 200, needed to confirm that valid membership grants access.
   it("sets workspaceId when user is a member", async () => {
     mockValidateWorkspaceMembership.mockResolvedValue(true);
     const app = createApp();
@@ -45,6 +47,7 @@ describe("workspaceMiddleware", () => {
     expect(body.workspaceId).toBe("ws-123");
   });
 
+  // X-Workspace-Id header is completely absent → 400 with workspace_id_required error, needed to catch missing scope header early.
   it("returns 400 when X-Workspace-Id header is missing", async () => {
     const app = createApp();
     const res = await app.request("/test");

--- a/backend/src/repositories/agent.test.ts
+++ b/backend/src/repositories/agent.test.ts
@@ -22,6 +22,7 @@ const { listAgentConfigs, getAgentConfigById, createAgentConfig, updateAgentConf
 beforeEach(() => { vi.clearAllMocks(); });
 
 describe("listAgentConfigs", () => {
+  // Non-archived agents exist → they are returned sorted by updatedAt desc with formatted profile_name and updated_at fields, needed to verify the listing query shapes output correctly.
   it("returns non-archived agents ordered by updatedAt desc", async () => {
     const rows = [
       { id: "a1", profileName: "Agent One", behavior: "", tools: [], skills: [], updatedAt: new Date(), firstUsedAt: null, autoAssignConversationLabels: true, responseTemplateGroups: [], handoffTopicGroups: [], contextGroups: [], assetGroups: [] },
@@ -35,6 +36,7 @@ describe("listAgentConfigs", () => {
     expect(result[0].updated_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
 
+  // Database query fails → empty array is returned instead of throwing, needed to ensure the repository handles errors gracefully without crashing callers.
   it("returns empty array on error", async () => {
     mockFrom.mockReturnValue({ where: vi.fn().mockReturnValue({ orderBy: vi.fn().mockRejectedValue(new Error("db down")) }) });
     const result = await listAgentConfigs("ws-1");
@@ -43,6 +45,7 @@ describe("listAgentConfigs", () => {
 });
 
 describe("getAgentConfigById", () => {
+  // Agent exists with the given id → single agent is returned with formatted profile_name, needed to confirm by-id lookups produce the correct shape.
   it("returns single agent when found", async () => {
     const row = { id: "a1", profileName: "Agent", behavior: "", tools: [], skills: [], updatedAt: new Date(), firstUsedAt: null, autoAssignConversationLabels: true, responseTemplateGroups: [], handoffTopicGroups: [], contextGroups: [], assetGroups: [] };
     mockFrom.mockReturnValue({ where: mockWhere.mockReturnValue({ limit: mockLimit }) });
@@ -52,6 +55,7 @@ describe("getAgentConfigById", () => {
     expect(result?.profile_name).toBe("Agent");
   });
 
+  // No agent matches the given id → null is returned, needed to verify the caller can distinguish "not found" from an error.
   it("returns null when not found", async () => {
     mockFrom.mockReturnValue({ where: mockWhere.mockReturnValue({ limit: mockLimit }) });
     mockLimit.mockResolvedValue([]);
@@ -61,6 +65,7 @@ describe("getAgentConfigById", () => {
 });
 
 describe("createAgentConfig", () => {
+  // Insert succeeds → ok:true and the new id are returned, needed to verify the happy path for agent creation.
   it("inserts with profile_name and returns id", async () => {
     mockReturning.mockResolvedValue([{ id: "new-id" }]);
     const result = await createAgentConfig({ workspace_id: "ws-1", profile_name: "New Agent" });
@@ -68,6 +73,7 @@ describe("createAgentConfig", () => {
     expect(result.id).toBe("new-id");
   });
 
+  // Database insert fails → ok:false is returned, needed to ensure creation errors are surfaced correctly to the caller.
   it("returns ok false on error", async () => {
     mockReturning.mockRejectedValue(new Error("db error"));
     const result = await createAgentConfig({ workspace_id: "ws-1", profile_name: "Fail" });
@@ -76,6 +82,7 @@ describe("createAgentConfig", () => {
 });
 
 describe("updateAgentConfig", () => {
+  // All updateable fields are provided → update succeeds returning ok:true, needed to confirm the full update payload works end-to-end.
   it("updates all fields and returns ok true", async () => {
     mockSet.mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
     const result = await updateAgentConfig({
@@ -85,6 +92,7 @@ describe("updateAgentConfig", () => {
     expect(result.ok).toBe(true);
   });
 
+  // Database update throws → ok:false is returned, needed to ensure the repository catches and reports update failures.
   it("returns ok false on error", async () => {
     mockSet.mockReturnValue({ where: vi.fn().mockRejectedValue(new Error("fail")) });
     const result = await updateAgentConfig({
@@ -96,6 +104,7 @@ describe("updateAgentConfig", () => {
 });
 
 describe("archiveAgentConfig", () => {
+  // Agent exists and is not yet archived → archivedAt is set and ok:true returned, needed to confirm the archive operation marks the record without deleting it.
   it("sets archivedAt and returns ok true", async () => {
     mockSet.mockReturnValue({ where: mockWhere.mockReturnValue({ returning: mockReturning }) });
     mockReturning.mockResolvedValue([{ id: "a1" }]);
@@ -104,6 +113,7 @@ describe("archiveAgentConfig", () => {
     expect(result.message).toBe("Agent archived");
   });
 
+  // Agent was already archived so 0 rows are updated → ok:false is returned, needed to prevent double-archiving and inform the caller.
   it("returns error if already archived (0 rows updated)", async () => {
     mockSet.mockReturnValue({ where: mockWhere.mockReturnValue({ returning: mockReturning }) });
     mockReturning.mockResolvedValue([]);
@@ -113,12 +123,14 @@ describe("archiveAgentConfig", () => {
 });
 
 describe("deleteAgentConfig", () => {
+  // Agent has not been used (firstUsedAt is null) and is not archived → deletion succeeds with ok:true, needed to ensure unused agents can be cleaned up.
   it("only deletes if firstUsedAt is null and not archived", async () => {
     mockReturning.mockResolvedValue([{ id: "a1" }]);
     const result = await deleteAgentConfig({ workspace_id: "ws-1", id: "a1" });
     expect(result.ok).toBe(true);
   });
 
+  // Agent has been used so 0 rows match the delete condition → ok:false is returned, needed to prevent accidental deletion of active agent configs.
   it("returns error when agent has been used", async () => {
     mockReturning.mockResolvedValue([]);
     const result = await deleteAgentConfig({ workspace_id: "ws-1", id: "a1" });
@@ -127,6 +139,7 @@ describe("deleteAgentConfig", () => {
 });
 
 describe("markAgentConfigFirstUsed", () => {
+  // firstUsedAt is currently null → timestamp is set, needed to verify the one-time recording of first agent usage.
   it("sets timestamp only if null", async () => {
     mockSet.mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
     await expect(markAgentConfigFirstUsed("ws-1", "a1")).resolves.toBeUndefined();

--- a/backend/src/repositories/contacts.test.ts
+++ b/backend/src/repositories/contacts.test.ts
@@ -21,6 +21,7 @@ beforeEach(() => {
 
 describe("contacts repository", () => {
   describe("createContact", () => {
+    // Valid contact data is provided → insert succeeds and returns ok:true with confirmation message, needed to verify single contact creation happy path.
     it("inserts and returns ok true", async () => {
       mockDb.insert.mockReturnValue({
         values: vi.fn().mockResolvedValue(undefined),
@@ -39,6 +40,7 @@ describe("contacts repository", () => {
       expect(result.message).toBe("Contact added");
     });
 
+    // Database insert throws → ok:false is returned, needed to ensure insertion failures are caught and reported without crashing.
     it("returns ok false on DB error", async () => {
       mockDb.insert.mockReturnValue({
         values: vi.fn().mockRejectedValue(new Error("DB error")),
@@ -58,6 +60,7 @@ describe("contacts repository", () => {
   });
 
   describe("createContactsBulk", () => {
+    // Multiple contact rows are provided → bulk insert succeeds and returns ok:true with import count, needed to verify mass contact import.
     it("inserts multiple rows and returns ok true", async () => {
       mockDb.insert.mockReturnValue({
         values: vi.fn().mockResolvedValue(undefined),
@@ -73,6 +76,7 @@ describe("contacts repository", () => {
       expect(result.message).toBe("Imported 2 contacts");
     });
 
+    // Bulk insert fails with DB error → ok:false is returned, needed to ensure the caller handles import failures properly.
     it("returns ok false on DB error", async () => {
       mockDb.insert.mockReturnValue({
         values: vi.fn().mockRejectedValue(new Error("DB error")),
@@ -88,6 +92,7 @@ describe("contacts repository", () => {
   });
 
   describe("updateContactIsTest", () => {
+    // A valid contact id and is_test value are given → execute succeeds and returns ok:true, needed to verify the test/sandbox toggling works.
     it("toggles is_test column and returns ok true", async () => {
       mockDb.execute.mockResolvedValue(undefined);
 
@@ -97,6 +102,7 @@ describe("contacts repository", () => {
       expect(result.ok).toBe(true);
     });
 
+    // Database execute fails → ok:false is returned, needed to catch runtime errors during the toggle operation.
     it("returns ok false on DB error", async () => {
       mockDb.execute.mockRejectedValue(new Error("DB error"));
 
@@ -108,6 +114,7 @@ describe("contacts repository", () => {
   });
 
   describe("listContactOptions", () => {
+    // Multiple contacts exist in the workspace → they are returned as formatted label strings with id+value, needed to verify the option dropdown data shape used by the UI.
     it("returns formatted labels", async () => {
       const mockFrom = vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
@@ -131,6 +138,7 @@ describe("contacts repository", () => {
       expect(result[1]?.label).toBe("Jane Smith (456)");
     });
 
+    // Query fails → empty array is returned gracefully, needed to avoid breaking callers on transient DB issues.
     it("returns empty array on DB error", async () => {
       const mockFromErr = vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
@@ -151,6 +159,7 @@ describe("contacts repository", () => {
   });
 
   describe("getContactIsTestForConversation", () => {
+    // No contact row matches the conversation → false is returned, needed to default to non-test when the conversation has no linked test contact.
     it("returns false when no row found", async () => {
       const mockWhere = vi.fn().mockReturnValue({
         limit: vi.fn().mockResolvedValue([]),
@@ -170,6 +179,7 @@ describe("contacts repository", () => {
       expect(result).toBe(false);
     });
 
+    // Contact linked to conversation has isTest:true → true is returned, needed to enable test-mode routing for that conversation.
     it("returns true when contact is_test is true", async () => {
       const mockWhere = vi.fn().mockReturnValue({
         limit: vi.fn().mockResolvedValue([{ isTest: true }]),

--- a/backend/src/repositories/conversation-labels.test.ts
+++ b/backend/src/repositories/conversation-labels.test.ts
@@ -21,6 +21,7 @@ const { listConversationLabels, createConversationLabel, validateLabelIdsForWork
 beforeEach(() => { vi.clearAllMocks(); });
 
 describe("listConversationLabels", () => {
+  // Labels exist for the workspace → they are returned as an array, needed to verify the listing query produces the correct label data.
   it("returns all labels for workspace", async () => {
     const rows = [
       { id: "l1", workspaceId: "ws-1", name: "VIP", description: "Important", createdAt: new Date(), updatedAt: new Date() },
@@ -32,6 +33,7 @@ describe("listConversationLabels", () => {
     expect(result[0].name).toBe("VIP");
   });
 
+  // Database query fails → empty array is returned gracefully, needed to avoid crashing callers during transient DB outages.
   it("returns empty on error", async () => {
     mockFrom.mockReturnValue({ where: vi.fn().mockReturnValue({ orderBy: vi.fn().mockRejectedValue(new Error("fail")) }) });
     const result = await listConversationLabels("ws-1");
@@ -40,6 +42,7 @@ describe("listConversationLabels", () => {
 });
 
 describe("createConversationLabel", () => {
+  // A valid label name is provided → insert succeeds returning ok:true with the new id, needed to confirm label creation happy path.
   it("inserts and returns id", async () => {
     mockReturning.mockResolvedValue([{ id: "new-label" }]);
     const result = await createConversationLabel({ workspaceId: "ws-1", name: "Tag", description: "" });
@@ -47,6 +50,7 @@ describe("createConversationLabel", () => {
     expect(result.id).toBe("new-label");
   });
 
+  // Duplicate label name causes a constraint violation → ok:false is returned, needed to ensure duplicate names are rejected gracefully.
   it("returns ok false on duplicate (Error with 'duplicate' in message)", async () => {
     mockReturning.mockRejectedValue(new Error("duplicate key value violates unique constraint"));
     const result = await createConversationLabel({ workspaceId: "ws-1", name: "Tag", description: "" });
@@ -55,12 +59,14 @@ describe("createConversationLabel", () => {
 });
 
 describe("validateLabelIdsForWorkspace", () => {
+  // All provided label IDs exist in the workspace → true is returned, needed to confirm successful validation before assigning labels.
   it("returns true when all IDs valid", async () => {
     mockFrom.mockReturnValue({ where: mockWhere.mockReturnValue(Promise.resolve([{ id: "l1" }, { id: "l2" }])) });
     const result = await validateLabelIdsForWorkspace("ws-1", ["l1", "l2"]);
     expect(result).toBe(true);
   });
 
+  // Some provided label IDs are missing from the workspace → false is returned, needed to prevent assigning non-existent labels.
   it("returns false when some IDs missing", async () => {
     mockFrom.mockReturnValue({ where: mockWhere.mockReturnValue(Promise.resolve([{ id: "l1" }])) });
     const result = await validateLabelIdsForWorkspace("ws-1", ["l1", "l2"]);

--- a/backend/src/repositories/skills.test.ts
+++ b/backend/src/repositories/skills.test.ts
@@ -28,6 +28,7 @@ const { createWorkspaceSkill, listActiveWorkspaceSkills, listWorkspaceSkills } =
 beforeEach(() => { vi.clearAllMocks(); });
 
 describe("createWorkspaceSkill", () => {
+  // Valid skill data with content is provided → content is uploaded to storage, row is inserted, and ok:true with skillId is returned, needed to verify the full create flow.
   it("inserts with storage-backed content key and returns ok true", async () => {
     mockStorageUpload.mockResolvedValue({ error: null });
     mockReturning.mockResolvedValue([{ id: "skill-1" }]);
@@ -41,6 +42,7 @@ describe("createWorkspaceSkill", () => {
     expect(result.skillId).toBe("skill-1");
   });
 
+  // displayName is empty → ok:false with validation message, needed to catch invalid input before hitting the database.
   it("fails with invalid skill name (empty displayName)", async () => {
     const result = await createWorkspaceSkill({
       workspaceId: "ws-1",
@@ -54,6 +56,7 @@ describe("createWorkspaceSkill", () => {
 });
 
 describe("listActiveWorkspaceSkills", () => {
+  // Only active skills exist for the workspace → they are returned filtered by isActive:true, needed to ensure the caller receives only usable skills.
   it("returns only active skills filtered by isActive true", async () => {
     const rows = [{ id: "s1", workspaceId: "ws-1", skillKey: "my_skill", displayName: "My Skill", description: "", storagePath: "", isActive: true, createdAt: new Date(), updatedAt: new Date() }];
     mockFrom.mockReturnValue({ where: mockWhere.mockReturnValue({ orderBy: mockOrderBy }) });
@@ -65,6 +68,7 @@ describe("listActiveWorkspaceSkills", () => {
 });
 
 describe("listWorkspaceSkills", () => {
+  // Both active and inactive skills exist → all are returned without filtering, needed to confirm the admin listing includes deactivated skills too.
   it("returns all skills with no isActive filter", async () => {
     const rows = [
       { id: "s1", workspaceId: "ws-1", skillKey: "active", displayName: "Active", description: "", storagePath: "", isActive: true, createdAt: new Date(), updatedAt: new Date() },

--- a/backend/src/repositories/tasks.test.ts
+++ b/backend/src/repositories/tasks.test.ts
@@ -22,6 +22,7 @@ const { createTask, cancelTaskById, listSchedulableAgents } =
 beforeEach(() => { vi.clearAllMocks(); });
 
 describe("createTask", () => {
+  // One-time task with full details including file URL → insert succeeds returning ok:true with task id, needed to verify complete task creation with optional fields.
   it("inserts with schedule, prompt, contact, file URL", async () => {
     mockReturning.mockResolvedValue([{ id: "task-1" }]);
     const result = await createTask({
@@ -42,6 +43,7 @@ describe("createTask", () => {
     expect(result.id).toBe("task-1");
   });
 
+  // Database insert fails → ok:false is returned, needed to surface creation failures to the caller without throwing.
   it("returns ok false on error", async () => {
     mockReturning.mockRejectedValue(new Error("db down"));
     const result = await createTask({
@@ -60,12 +62,14 @@ describe("createTask", () => {
 });
 
 describe("cancelTaskById", () => {
+  // Task exists and update succeeds → true is returned, needed to confirm the cancel operation marks the task cleanly.
   it("marks cancelled and returns true", async () => {
     mockSet.mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
     const result = await cancelTaskById("ws-1", "task-1");
     expect(result).toBe(true);
   });
 
+  // Database update fails → false is returned, needed to signal the caller that cancellation did not complete.
   it("returns false on error", async () => {
     mockSet.mockReturnValue({ where: vi.fn().mockRejectedValue(new Error("fail")) });
     const result = await cancelTaskById("ws-1", "task-1");
@@ -74,6 +78,7 @@ describe("cancelTaskById", () => {
 });
 
 describe("listSchedulableAgents", () => {
+  // Agents are directly attached to a WhatsApp connection → they are returned with profile_name, needed to verify the join-based query works.
   it("returns agents attached to a WhatsApp connection", async () => {
     const innerJoin = vi.fn().mockReturnValue({
       where: vi.fn().mockReturnValue({
@@ -88,6 +93,7 @@ describe("listSchedulableAgents", () => {
     expect(result[0].profile_name).toBe("Bot");
   });
 
+  // An authorized WhatsApp connection exists but no agent is directly attached → all workspace agents are still returned, needed to cover the fallback path where any authorized connection makes all agents schedulable.
   it("returns workspace agents when authorized WhatsApp exists without attachment", async () => {
     const innerJoin = vi.fn().mockReturnValue({
       where: vi.fn().mockReturnValue({

--- a/backend/src/repositories/whatsapp.test.ts
+++ b/backend/src/repositories/whatsapp.test.ts
@@ -22,6 +22,7 @@ const { createConnection, bindAgentToWhatsappConnection, updateConnectionMode, d
 beforeEach(() => { vi.clearAllMocks(); });
 
 describe("createConnection", () => {
+  // Valid display name and token → insert succeeds returning ok:true with connection id, needed to verify WhatsApp connection creation.
   it("inserts with display name", async () => {
     mockReturning.mockResolvedValue([{ id: "conn-1" }]);
     const result = await createConnection({
@@ -33,6 +34,7 @@ describe("createConnection", () => {
     expect(result.id).toBe("conn-1");
   });
 
+  // Display name exceeds 120 chars → ok:false with display_name_too_long, needed to enforce the length constraint before hitting the DB.
   it("returns error when display name > 120 chars", async () => {
     const longName = "x".repeat(121);
     const result = await createConnection({
@@ -46,6 +48,7 @@ describe("createConnection", () => {
 });
 
 describe("bindAgentToWhatsappConnection", () => {
+  // Valid agent and connection ids → link succeeds with ok:true, needed to verify the agent-to-connection association works.
   it("links agent config to connection", async () => {
     mockSet.mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
     const result = await bindAgentToWhatsappConnection("ws-1", "agent-1", "conn-1");
@@ -54,12 +57,14 @@ describe("bindAgentToWhatsappConnection", () => {
 });
 
 describe("updateConnectionMode", () => {
+  // A valid mode string (testing) is provided → update succeeds with ok:true, needed to confirm mode transitions work.
   it("sets Inactive/Testing/Live mode", async () => {
     mockSet.mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
     const result = await updateConnectionMode("ws-1", "conn-1", "testing");
     expect(result.ok).toBe(true);
   });
 
+  // An unrecognized mode string is passed → ok:false is returned, needed to reject invalid mode values at the repository boundary.
   it("rejects invalid mode", async () => {
     // @ts-expect-error - testing invalid mode input
     const result = await updateConnectionMode("ws-1", "conn-1", "invalid");
@@ -68,6 +73,7 @@ describe("updateConnectionMode", () => {
 });
 
 describe("deleteConnectionByWorkspace", () => {
+  // Connection exists under workspace → row is removed and deleted:true is returned, needed to verify successful connection cleanup.
   it("removes connection row", async () => {
     mockWhere.mockReturnValue({ returning: mockReturning });
     mockReturning.mockResolvedValue([{ id: "conn-1" }]);
@@ -76,6 +82,7 @@ describe("deleteConnectionByWorkspace", () => {
     expect(result.deleted).toBe(true);
   });
 
+  // Connection does not exist → ok:true but deleted:false is returned, needed to handle idempotent deletion gracefully.
   it("returns not found when absent", async () => {
     mockWhere.mockReturnValue({ returning: mockReturning });
     mockReturning.mockResolvedValue([]);

--- a/backend/src/routes/auth.integration.test.ts
+++ b/backend/src/routes/auth.integration.test.ts
@@ -115,6 +115,7 @@ beforeEach(async () => {
 });
 
 describe("POST /register", () => {
+  // Valid email + password with registration enabled → user created, tokens returned, owner workspace provisioned with 200, needed to verify successful registration flow.
   it("creates user, returns tokens with 200", async () => {
     const res = await app.request("/register", {
       method: "POST",
@@ -133,6 +134,7 @@ describe("POST /register", () => {
     expect(provisionOwnerWorkspaceMock).toHaveBeenCalled();
   });
 
+  // Public registration is off and no valid invite → 403 is returned with registration_disabled, needed to enforce the instance-wide registration gate.
   it("rejects registration when public registration is off and no invite", async () => {
     getAllowPublicRegistrationMock.mockResolvedValue(false);
 
@@ -150,6 +152,7 @@ describe("POST /register", () => {
     expect(body.error).toBe("registration_disabled");
   });
 
+  // Email already exists in the database → 409 is returned with email_already_exists, needed to prevent duplicate user registration.
   it("rejects duplicate email with 409", async () => {
     findUserByEmailMock.mockResolvedValue(mockUser);
 
@@ -167,6 +170,7 @@ describe("POST /register", () => {
     expect(body.error).toBe("email_already_exists");
   });
 
+  // Email format is invalid → 400 with invalid_payload, needed to validate input at the route boundary via Zod schema.
   it("rejects invalid email format with 400", async () => {
     const res = await app.request("/register", {
       method: "POST",
@@ -182,6 +186,7 @@ describe("POST /register", () => {
     expect(body.error).toBe("invalid_payload");
   });
 
+  // Password is too short (<8 chars) → 400 with invalid_payload, needed to enforce minimum password length policy via Zod schema.
   it("rejects short password with 400", async () => {
     const res = await app.request("/register", {
       method: "POST",
@@ -199,6 +204,7 @@ describe("POST /register", () => {
 });
 
 describe("POST /login", () => {
+  // Valid email + password → access token in body, refresh token in body and set-cookie, user object returned with 200, needed to verify successful login flow.
   it("returns access token and sets refresh cookie with 200", async () => {
     findUserByEmailMock.mockResolvedValue(mockUser);
 
@@ -221,6 +227,7 @@ describe("POST /login", () => {
     expect(setCookieHeader).toContain("senqo_refresh");
   });
 
+  // Correct email but wrong password → 401 with invalid_credentials, needed to reject wrong credentials without revealing which field was wrong.
   it("rejects wrong password with 401", async () => {
     findUserByEmailMock.mockResolvedValue(mockUser);
     verifyPasswordMock.mockResolvedValue(false);
@@ -239,6 +246,7 @@ describe("POST /login", () => {
     expect(body.error).toBe("invalid_credentials");
   });
 
+  // Email does not exist in the database → 401 with invalid_credentials, needed to avoid leaking whether an account exists.
   it("rejects unknown email with 401", async () => {
     const res = await app.request("/login", {
       method: "POST",
@@ -256,6 +264,7 @@ describe("POST /login", () => {
 });
 
 describe("POST /refresh", () => {
+  // Valid refresh cookie present with non-disabled user → new access and refresh tokens returned with 200, needed to verify token rotation happy path.
   it("returns new access token from valid refresh cookie with 200", async () => {
     findUserByIdMock.mockResolvedValue(mockUser);
 
@@ -272,6 +281,7 @@ describe("POST /refresh", () => {
     expect(body.refreshToken).toBe("refresh-token-user-1");
   });
 
+  // No refresh cookie in the request → 401 with no_refresh_token, needed to reject requests missing the required cookie.
   it("rejects expired or missing refresh token with 401", async () => {
     const res = await app.request("/refresh", {
       method: "POST",
@@ -282,6 +292,7 @@ describe("POST /refresh", () => {
     expect(body.error).toBe("no_refresh_token");
   });
 
+  // Refresh cookie contains a token that fails JWT verification → 401 with invalid_refresh_token, needed to reject tampered or expired tokens.
   it("rejects invalid refresh token with 401", async () => {
     const res = await app.request("/refresh", {
       method: "POST",
@@ -297,6 +308,7 @@ describe("POST /refresh", () => {
 });
 
 describe("POST /logout", () => {
+  // Request to logout → refresh cookie is cleared and 200 with ok:true, needed to verify the client can reliably end a session.
   it("clears refresh cookie and returns 200 with ok:true", async () => {
     const res = await app.request("/logout", {
       method: "POST",

--- a/backend/src/services/conversation-manual.test.ts
+++ b/backend/src/services/conversation-manual.test.ts
@@ -34,6 +34,7 @@ beforeEach(() => {
 });
 
 describe("sendManualConversationMessage", () => {
+  // Valid target, message, and all sub-operations succeed → ok:true with WhatsApp message id, needed to verify the full manual send pipeline works end-to-end.
   it("persists message, mirrors to agent transcript, and returns ok on success", async () => {
     mockGetManualWhatsappSendTarget.mockResolvedValue(mockTarget);
     mockSendTextMessage.mockResolvedValue({ messageId: "wa-msg-1" });
@@ -62,6 +63,7 @@ describe("sendManualConversationMessage", () => {
     expect(mockPersistHumanOutboundText).toHaveBeenCalled();
   });
 
+  // Conversation has no active WhatsApp target → ok:false with "not connected" error, needed to prevent sending to unreachable recipients.
   it("returns error when getManualWhatsappSendTarget returns null", async () => {
     mockGetManualWhatsappSendTarget.mockResolvedValue(null);
 
@@ -78,6 +80,7 @@ describe("sendManualConversationMessage", () => {
     expect(mockSendTextMessage).not.toHaveBeenCalled();
   });
 
+  // Message is only whitespace → ok:false with validation error, needed to catch empty input before attempting send.
   it("returns error when message is empty", async () => {
     const result = await sendManualConversationMessage({
       workspaceId: "ws-1",
@@ -92,6 +95,7 @@ describe("sendManualConversationMessage", () => {
     expect(mockGetManualWhatsappSendTarget).not.toHaveBeenCalled();
   });
 
+  // WhatsApp send succeeds but persisting the conversation message fails → ok:false with save error, needed to surface partial failures after send.
   it("returns error when createConversationMessage fails", async () => {
     mockGetManualWhatsappSendTarget.mockResolvedValue(mockTarget);
     mockSendTextMessage.mockResolvedValue({ messageId: "wa-msg-1" });
@@ -109,6 +113,7 @@ describe("sendManualConversationMessage", () => {
     }
   });
 
+  // Message has leading/trailing whitespace → it is trimmed before being saved and sent, needed to ensure clean content is stored and delivered.
   it("trims whitespace from message before sending", async () => {
     mockGetManualWhatsappSendTarget.mockResolvedValue(mockTarget);
     mockSendTextMessage.mockResolvedValue({ messageId: "wa-msg-2" });

--- a/backend/src/services/custom-tool-compile.test.ts
+++ b/backend/src/services/custom-tool-compile.test.ts
@@ -9,6 +9,7 @@ const unionInputSource = `export async function execute(
 }`;
 
 describe("compileCustomToolSource → accepts string literal union input types", () => {
+  // Input parameter uses a string literal union ("alpha" | "beta") → the resulting JSON schema includes enum with both values and required fields, needed to verify union types are properly compiled into schema constraints.
   it("returns metadata with enum schema for union properties", async () => {
     const result = await compileCustomToolSource(unionInputSource);
     expect(result.ok).toBe(true);

--- a/backend/src/services/inbound-ai-debounce-schedule.test.ts
+++ b/backend/src/services/inbound-ai-debounce-schedule.test.ts
@@ -20,6 +20,7 @@ beforeEach(() => {
 });
 
 describe("scheduleInboundAiDebounced", () => {
+  // Inbound conversation event triggers debounced AI scheduling → the underlying job scheduler is called with the correct conversation input, needed to verify the debounce layer delegates to the job queue correctly.
   it("schedules debounced inbound via job queue", async () => {
     await scheduleInboundAiDebounced(input);
 

--- a/backend/src/services/inbound-ai-mode.test.ts
+++ b/backend/src/services/inbound-ai-mode.test.ts
@@ -6,62 +6,76 @@ import {
 } from "../services/inbound-ai-mode.js";
 
 describe("normalizeWhatsappConnectionMode", () => {
+  // Raw mode is "testing" → "testing" is returned, needed to ensure known active/test modes pass through unchanged.
   it("returns 'testing' when raw is 'testing'", () => {
     expect(normalizeWhatsappConnectionMode("testing")).toBe("testing");
   });
 
+  // Raw mode is "live" → "live" is returned, needed to ensure live mode passes through unchanged.
   it("returns 'live' when raw is 'live'", () => {
     expect(normalizeWhatsappConnectionMode("live")).toBe("live");
   });
 
+  // Raw mode is null (e.g. from a missing DB field) → "inactive" is returned, needed to default nulls to the inactive/safe state.
   it("returns 'inactive' when raw is null", () => {
     expect(normalizeWhatsappConnectionMode(null)).toBe("inactive");
   });
 
+  // Raw mode is undefined → "inactive" is returned, needed to handle completely absent values gracefully.
   it("returns 'inactive' when raw is undefined", () => {
     expect(normalizeWhatsappConnectionMode(undefined)).toBe("inactive");
   });
 
+  // Raw mode is an unknown string that isn't a valid mode → "inactive" is returned, needed to map any unexpected values to the safe default.
   it("returns 'inactive' when raw is an unknown string", () => {
     expect(normalizeWhatsappConnectionMode("unknown")).toBe("inactive");
   });
 });
 
 describe("connectionAiEnabledForComposer", () => {
+  // Mode is "inactive" → composer AI is disabled regardless of test contact flag, needed to ensure no AI on inactive connections.
   it("returns false when mode is 'inactive'", () => {
     expect(connectionAiEnabledForComposer("inactive", false)).toBe(false);
   });
 
+  // Mode is "live" → composer AI is enabled regardless of test contact flag, needed to ensure AI works for all live contacts.
   it("returns true when mode is 'live'", () => {
     expect(connectionAiEnabledForComposer("live", false)).toBe(true);
   });
 
+  // Mode is "testing" and contact is a test contact → AI is enabled, needed to allow AI for designated test contacts during testing mode.
   it("returns true when mode is 'testing' and isTestContact is true", () => {
     expect(connectionAiEnabledForComposer("testing", true)).toBe(true);
   });
 
+  // Mode is "testing" but contact is not a test contact → AI is disabled, needed to prevent AI from responding to non-test contacts during testing mode.
   it("returns false when mode is 'testing' and isTestContact is false", () => {
     expect(connectionAiEnabledForComposer("testing", false)).toBe(false);
   });
 });
 
 describe("shouldRunInboundAi", () => {
+  // handlingMode is "human" even with live mode → returns false, needed to ensure human-only conversations never trigger AI.
   it("returns false when handlingMode is 'human'", () => {
     expect(shouldRunInboundAi("live", true, "human")).toBe(false);
   });
 
+  // Mode is "inactive" → returns false, needed to block AI completely when the connection is not active.
   it("returns false when mode is 'inactive'", () => {
     expect(shouldRunInboundAi("inactive", true, "ai")).toBe(false);
   });
 
+  // Mode is "testing" and contact is not a test contact → returns false, needed to restrict AI to test contacts only during testing mode.
   it("returns false when mode is 'testing' and isTestContact is false", () => {
     expect(shouldRunInboundAi("testing", false, "ai")).toBe(false);
   });
 
+  // Mode is "testing" and contact is a test contact with ai handling → returns true, needed to allow AI to respond to test contacts in testing mode.
   it("returns true when mode is 'testing' and isTestContact is true", () => {
     expect(shouldRunInboundAi("testing", true, "ai")).toBe(true);
   });
 
+  // Mode is "live" and handlingMode is "ai" → returns true, needed to confirm AI runs for all contacts when live with ai handling.
   it("returns true when mode is 'live' and handlingMode is 'ai'", () => {
     expect(shouldRunInboundAi("live", false, "ai")).toBe(true);
   });

--- a/backend/src/services/job-scheduler.test.ts
+++ b/backend/src/services/job-scheduler.test.ts
@@ -38,6 +38,7 @@ beforeEach(() => {
 });
 
 describe("scheduleAgentTask", () => {
+  // oneTimeAt is in the future → sendAfter is called to delay task execution, needed to verify that future-dated tasks are scheduled with the correct delay.
   it("enqueues delayed task with sendAfter when oneTimeAt is in the future", async () => {
     const future = new Date(Date.now() + 60_000).toISOString();
     const result = await scheduleAgentTask({
@@ -55,11 +56,13 @@ describe("scheduleAgentTask", () => {
 });
 
 describe("cancelScheduledTask", () => {
+  // Payload has a valid jobId → the corresponding job is cancelled, needed to verify that pg-boss cancel is called for trackable jobs.
   it("cancels job when jobId is present in payload", async () => {
     await cancelScheduledTask({ jobId: "job-1", queue: "task-execute" });
     expect(mockCancel).toHaveBeenCalledWith("task-execute", "job-1");
   });
 
+  // Payload lacks jobId (legacy qstash format) → no cancel is attempted, needed to handle legacy payloads that aren't tracked by pg-boss job ids.
   it("no-ops when jobId is missing (legacy qstash payload)", async () => {
     await cancelScheduledTask({ response: { messageId: "old-qstash" } });
     expect(mockCancel).not.toHaveBeenCalled();
@@ -67,6 +70,7 @@ describe("cancelScheduledTask", () => {
 });
 
 describe("scheduleInboundAiDebouncedJob", () => {
+  // A previous pending job exists for the conversation → it is cancelled before scheduling a new one, the new job is sent with debounce delay, and the pending record is upserted, needed to verify the full debounce loop: cancel-old, send-new, track.
   it("cancels previous pending job before scheduling a new one", async () => {
     mockGetPendingJobId.mockResolvedValue("job-old-1");
 

--- a/backend/src/services/task-schedule.test.ts
+++ b/backend/src/services/task-schedule.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { taskScheduleSchema, toCronSchedule } from "../services/task-schedule.js";
 
 describe("taskScheduleSchema", () => {
+  // scheduleType is "one_time" and oneTimeAt is a valid datetime → schema validates successfully, needed to ensure the happy-path input shape is accepted.
   it("validates a valid one-time schedule", () => {
     const result = taskScheduleSchema.safeParse({
       scheduleType: "one_time",
@@ -10,6 +11,7 @@ describe("taskScheduleSchema", () => {
     expect(result.success).toBe(true);
   });
 
+  // scheduleType is "one_time" but oneTimeAt is missing → schema rejects with error on oneTimeAt path, needed to enforce the required field.
   it("rejects missing oneTimeAt", () => {
     const result = taskScheduleSchema.safeParse({
       scheduleType: "one_time",
@@ -20,6 +22,7 @@ describe("taskScheduleSchema", () => {
     }
   });
 
+  // scheduleType is "recurring" which is not in the enum → schema rejects, needed because the schema currently only allows "one_time".
   it("rejects scheduleType other than 'one_time'", () => {
     const result = taskScheduleSchema.safeParse({
       scheduleType: "recurring",
@@ -30,6 +33,7 @@ describe("taskScheduleSchema", () => {
 });
 
 describe("toCronSchedule", () => {
+  // A valid local datetime string is provided → cronExpression is null and oneTimeAt is converted to UTC ISO with milliseconds, needed to verify the date conversion and default timezone assignment.
   it("returns cronExpression null and converts local datetime to ISO string", () => {
     const result = toCronSchedule({
       scheduleType: "one_time",
@@ -40,6 +44,7 @@ describe("toCronSchedule", () => {
     expect(result.timezone).toBe("UTC");
   });
 
+  // Input already has a Z suffix (UTC) → it is preserved and formatted with milliseconds, needed to confirm pre-formatted UTC strings work correctly.
   it("handles Z-suffixed UTC ISO string correctly", () => {
     const result = toCronSchedule({
       scheduleType: "one_time",
@@ -50,6 +55,7 @@ describe("toCronSchedule", () => {
     expect(result.timezone).toBe("UTC");
   });
 
+  // The oneTimeAt string is not parseable as a date → throws "invalid_one_time_date", needed to catch garbage input before it reaches scheduling.
   it("throws 'invalid_one_time_date' on invalid date input", () => {
     expect(() =>
       toCronSchedule({

--- a/e2e/custom-tools.spec.ts
+++ b/e2e/custom-tools.spec.ts
@@ -221,6 +221,7 @@ async function openToolEditor(page: Page) {
 }
 
 test.describe("Custom tools catalog", () => {
+  // Happy path: opening a tool in the editor shows the tool name, description, and a disabled Save button (clean state).
   test("opens selected tool in editor with clean save state", async ({ page }) => {
     const toolState = { current: createToolDetail() };
     await seedSession(page);
@@ -233,6 +234,7 @@ test.describe("Custom tools catalog", () => {
     await expect(fields.nth(1)).toHaveValue("Demo tool for E2E");
   });
 
+  // Save button must be disabled initially, enabled after edits, and disabled again after a successful save with cleared dirty state.
   test("enables Save changes only after edits and clears dirty after save", async ({ page }) => {
     const toolState = { current: createToolDetail() };
     await seedSession(page);
@@ -250,6 +252,7 @@ test.describe("Custom tools catalog", () => {
     await expect(page.getByRole("textbox").nth(1)).toHaveValue("Updated description");
   });
 
+  // Editing the test input JSON must enable Save, and the edited value must persist in the UI after saving.
   test("treats test input JSON edits as unsaved until Save changes", async ({ page }) => {
     const toolState = { current: createToolDetail() };
     await seedSession(page);

--- a/e2e/instance-auth.spec.ts
+++ b/e2e/instance-auth.spec.ts
@@ -205,6 +205,7 @@ async function mockAdminApi(page: Page) {
 }
 
 test.describe("Instance auth", () => {
+  // Happy path: user with invite token signs up, sees empty workspace chooser, creates a workspace, lands on its dashboard.
   test("registration invite signup → empty chooser → create workspace", async ({ page }) => {
     const workspaceState = { workspaces: [] as WorkspaceListItem[] };
 
@@ -237,6 +238,7 @@ test.describe("Instance auth", () => {
     await expect(page.getByRole("link", { name: "Dashboard" })).toBeVisible();
   });
 
+  // When public registration is off and no invite is provided, the sign-up page must show a blocked-state message and disable inputs.
   test("open sign-up blocked when public registration is off and no invite", async ({ page }) => {
     await mockAuthApi(page, { allowPublicRegistration: false });
 
@@ -247,6 +249,7 @@ test.describe("Instance auth", () => {
     await expect(page.getByLabel("Email")).toBeDisabled();
   });
 
+  // A superadmin user must see the Instance admin link on the workspace chooser, navigate to it, and see admin panel content.
   test("superadmin opens Instance admin from Workspaces page", async ({ page }) => {
     await seedAuthTokens(page);
     await mockAuthApi(page, { isInstanceAdmin: true });

--- a/e2e/senqo.spec.ts
+++ b/e2e/senqo.spec.ts
@@ -209,6 +209,7 @@ function mockUserApi(page: import("@playwright/test").Page) {
 // ── 6.1 Auth Flow ───────────────────────────────────────────────────────────
 
 test.describe("6.1 Auth Flow", () => {
+  // Happy path: user fills in the sign-up form, submits, and is redirected away from the sign-up page (to the dashboard).
   test("visit /sign-up → fill form → submit → redirected to dashboard", async ({ page }) => {
     await mockAuthApi(page);
     await mockUserApi(page);
@@ -226,6 +227,7 @@ test.describe("6.1 Auth Flow", () => {
     await page.waitForURL((u) => !u.pathname.startsWith("/sign-up"), { timeout: 10_000 });
   });
 
+  // Happy path: existing user fills in the sign-in form, submits, and is redirected away from the sign-in page.
   test("visit /sign-in → fill form → submit → redirected away from sign-in", async ({ page }) => {
     await mockAuthApi(page);
     await mockUserApi(page);
@@ -241,6 +243,7 @@ test.describe("6.1 Auth Flow", () => {
     await page.waitForURL((u) => !u.pathname.startsWith("/sign-in"), { timeout: 10_000 });
   });
 
+  // Unauthenticated users visiting a protected route must be redirected to the sign-in page.
   test("visit protected route without auth → redirected to /sign-in", async ({ page }) => {
     await mockAuthApi(page);
     await mockUserApi(page);
@@ -260,6 +263,7 @@ test.describe("6.3 CRM", () => {
     await mockUserApi(page);
   });
 
+  // User with seeded auth tokens navigates to the CRM page and sees a valid URL (contact data is rendered via mocks).
   test("navigate to /crm → see contact table with rows", async ({ page }) => {
     // Seed auth tokens so the app thinks we're logged in
     await page.evaluate(() => {
@@ -297,6 +301,7 @@ test.describe("6.4 Agent Setup", () => {
     });
   });
 
+  // Smoke test: navigating to the agent page loads successfully without errors.
   test("navigate to /agent → see agent page", async ({ page }) => {
     await page.goto("/agent");
     await page.waitForTimeout(2000);
@@ -320,6 +325,7 @@ test.describe("6.5 WhatsApp Connection", () => {
     });
   });
 
+  // Smoke test: navigating to the connection page loads successfully without errors.
   test("navigate to /connect → see connect page", async ({ page }) => {
     await page.goto("/connect");
     await page.waitForTimeout(2000);
@@ -343,6 +349,7 @@ test.describe("6.6 Tasks", () => {
     });
   });
 
+  // Smoke test: navigating to the tasks page loads successfully without errors.
   test("navigate to /tasks → see tasks page", async ({ page }) => {
     await page.goto("/tasks");
     await page.waitForTimeout(2000);
@@ -366,6 +373,7 @@ test.describe("6.7 Settings", () => {
     });
   });
 
+  // Smoke test: navigating to the profile settings page loads without errors.
   test("navigate to /settings/profile → see profile section", async ({ page }) => {
     await page.goto("/settings/profile");
     await page.waitForTimeout(2000);
@@ -373,6 +381,7 @@ test.describe("6.7 Settings", () => {
     expect(url).toBeTruthy();
   });
 
+  // Smoke test: navigating to the API keys settings page loads without errors.
   test("navigate to /settings/api-keys → see API keys section", async ({ page }) => {
     await page.goto("/settings/api-keys");
     await page.waitForTimeout(2000);
@@ -380,6 +389,7 @@ test.describe("6.7 Settings", () => {
     expect(url).toBeTruthy();
   });
 
+  // Smoke test: navigating to the team settings page loads without errors.
   test("navigate to /settings/team → see team section", async ({ page }) => {
     await page.goto("/settings/team");
     await page.waitForTimeout(2000);

--- a/frontend/src/components/ui/inline-help-hint.test.tsx
+++ b/frontend/src/components/ui/inline-help-hint.test.tsx
@@ -3,6 +3,8 @@ import userEvent from "@testing-library/user-event";
 import { InlineHelpHint } from "./inline-help-hint";
 
 describe("inline-help-hint", () => {
+  // Confirms the InlineHelpHint renders a button with the correct accessible label.
+  // Ensures the help trigger is discoverable by screen readers and assistive technologies.
   it("renders a help trigger button with aria-label", () => {
     render(
       <InlineHelpHint label="Learn more">
@@ -13,6 +15,8 @@ describe("inline-help-hint", () => {
     expect(screen.getByRole("button", { name: "Learn more" })).toBeInTheDocument();
   });
 
+  // Verifies that clicking the button shows the tooltip content in a portal.
+  // Ensures the explanatory copy (i-button pattern per DESIGN.md) is accessible on user action.
   it("shows tooltip content when button clicked", async () => {
     const user = userEvent.setup();
 

--- a/frontend/src/components/ui/spinner.test.tsx
+++ b/frontend/src/components/ui/spinner.test.tsx
@@ -2,6 +2,8 @@ import { render, screen } from "@testing-library/react";
 import { Spinner, PageLoader } from "./spinner";
 
 describe("Spinner", () => {
+  // Confirms the Spinner renders with role="status" and aria-label="Loading".
+  // Ensures screen readers can announce loading state to assistive technology users.
   it("renders loading indicator with role status and aria-label Loading", () => {
     render(<Spinner />);
     const status = screen.getByRole("status");
@@ -10,11 +12,15 @@ describe("Spinner", () => {
 });
 
 describe("PageLoader", () => {
+  // Verifies PageLoader shows the default "Loading…" label when no custom label is provided.
+  // Ensures the page-level loading state always displays clear feedback text.
   it('renders with default Loading… label', () => {
     render(<PageLoader />);
     expect(screen.getByText("Loading…")).toBeInTheDocument();
   });
 
+  // Confirms PageLoader renders a custom label when one is provided.
+  // Ensures callers can show context-specific loading messages (e.g. "Loading dashboard…").
   it("renders with custom label", () => {
     render(<PageLoader label="Please wait…" />);
     expect(screen.getByText("Please wait…")).toBeInTheDocument();

--- a/frontend/src/hooks/useAgentConfigFormDirty.test.ts
+++ b/frontend/src/hooks/useAgentConfigFormDirty.test.ts
@@ -39,6 +39,8 @@ describe("useAgentConfigFormDirty helpers", () => {
   const rtGroup: WorkspaceResponseTemplateGroupSummary = { id: "rt1" };
   const ctxGroup: WorkspaceContextGroupSummary = { id: "ctx1" };
 
+  // Verifies that agentProfileNameDirty detects when the profile name has changed from baseline.
+  // Enables the inline Save button next to the agent name field when the user edits it.
   it("agentProfileNameDirty returns true when field differs from baseline", () => {
     const baseline = buildAgentConfigFormBaseline({
       agent,
@@ -54,6 +56,8 @@ describe("useAgentConfigFormDirty helpers", () => {
     expect(agentProfileNameDirty(baseline, changed)).toBe(true);
   });
 
+  // Confirms agentProfileNameDirty returns false when profile name matches the baseline exactly.
+  // Prevents showing a stale Save button when no actual changes have been made to the name.
   it("agentProfileNameDirty returns false when field matches baseline", () => {
     const baseline = buildAgentConfigFormBaseline({
       agent,
@@ -68,6 +72,8 @@ describe("useAgentConfigFormDirty helpers", () => {
     expect(agentProfileNameDirty(baseline, { ...baseline })).toBe(false);
   });
 
+  // Verifies that agentProfileBehaviorDirty detects when the behavior text has changed from baseline.
+  // Enables the inline Save button next to the agent behavior field so users can persist edits.
   it("agentProfileBehaviorDirty returns true when behavior differs", () => {
     const baseline = buildAgentConfigFormBaseline({
       agent,

--- a/frontend/src/hooks/useAgents.test.tsx
+++ b/frontend/src/hooks/useAgents.test.tsx
@@ -23,6 +23,8 @@ function wrapper() {
 beforeEach(() => { vi.clearAllMocks(); });
 
 describe("useAgents", () => {
+  // Confirms the hook fetches the agent list and auxiliary data (tools, skills, connections) on mount.
+  // Ensures the agent setup page has all data needed to configure an agent.
   it("fetches agent list on mount and returns data state", async () => {
     mockGet.mockResolvedValueOnce({ agents: [{ id: "a1", profile_name: "Bot", behavior: "", tools: [], skills: [], response_template_groups: [], handoff_topic_groups: [], context_groups: [], asset_groups: [], auto_assign_conversation_labels: false }], agentIdsWithConnection: [], responseTemplateGroups: [], handoffTopicGroups: [], workspaceContextGroups: [], workspaceAssetGroups: [] });
     mockGet.mockResolvedValueOnce({ tools: [] });

--- a/frontend/src/hooks/useApiKeys.test.ts
+++ b/frontend/src/hooks/useApiKeys.test.ts
@@ -11,6 +11,8 @@ const { useApiKeys } = await import("@/hooks/useApiKeys");
 beforeEach(() => { vi.clearAllMocks(); });
 
 describe("useApiKeys", () => {
+  // Confirms the hook fetches API keys from the backend and returns them in the items array.
+  // Ensures the API keys management page can list all keys for the workspace.
   it("fetches keys and returns list", async () => {
     mockGet.mockResolvedValue({
       apiKeys: [{ id: "k1", label: "Production", keyPrefix: "sk_senqo_12", expiresAt: null, createdAt: "2025-01-01" }],

--- a/frontend/src/hooks/useAuth.test.tsx
+++ b/frontend/src/hooks/useAuth.test.tsx
@@ -17,6 +17,8 @@ function wrapper({ children }: { children: React.ReactNode }) {
 beforeEach(() => { vi.clearAllMocks(); });
 
 describe("useAuth", () => {
+  // Confirms that when getSession returns a user object, the hook exposes it and sets loading=false.
+  // Ensures authenticated users see their profile and the app doesn't redirect them to sign-in.
   it("returns user when authenticated", async () => {
     mockGetSession.mockResolvedValue({ id: "u1", email: "a@b.com" });
     const { result } = renderHook(() => useAuth(), { wrapper });
@@ -25,6 +27,8 @@ describe("useAuth", () => {
     expect(result.current.loading).toBe(false);
   });
 
+  // Confirms that when getSession returns null, the hook sets user=null and loading=false.
+  // Ensures unauthenticated users are correctly identified so the app can redirect to sign-in.
   it("returns user null when not authenticated", async () => {
     mockGetSession.mockResolvedValue(null);
     const { result } = renderHook(() => useAuth(), { wrapper });

--- a/frontend/src/hooks/useConnections.test.tsx
+++ b/frontend/src/hooks/useConnections.test.tsx
@@ -23,6 +23,8 @@ function wrapper() {
 beforeEach(() => { vi.clearAllMocks(); });
 
 describe("useConnections", () => {
+  // Confirms the hook fetches the connections list from the API and exposes them in state.
+  // Ensures the channels page can display all WhatsApp/other connections for the workspace.
   it("fetches connection list", async () => {
     mockGet.mockResolvedValue({
       connections: [{ id: "conn-1", display_name: "My WA", agent_config_id: null, mode: "inactive", status: "pending_qr" }],

--- a/frontend/src/hooks/useContactOptions.test.ts
+++ b/frontend/src/hooks/useContactOptions.test.ts
@@ -13,6 +13,8 @@ beforeEach(() => {
 });
 
 describe("useContactOptions", () => {
+  // Verifies the hook fetches contact dropdown options when enabled=true and returns the list.
+  // Ensures autocomplete/select fields that need contact data can populate their options on demand.
   it("fetches contact dropdown options when enabled", async () => {
     mockGet.mockResolvedValue({
       contacts: [
@@ -30,6 +32,8 @@ describe("useContactOptions", () => {
     expect(mockGet).toHaveBeenCalledWith("/api/user/contacts/options");
   });
 
+  // Confirms the hook skips the API call when enabled=false and returns empty/clean state.
+  // Prevents unnecessary network requests for contact dropdowns that aren't visible or needed.
   it("skips fetch when enabled is false", () => {
     const { result } = renderHook(() => useContactOptions(false));
 

--- a/frontend/src/hooks/useContacts.test.ts
+++ b/frontend/src/hooks/useContacts.test.ts
@@ -9,6 +9,8 @@ const { useContacts } = await import("@/hooks/useContacts");
 beforeEach(() => { vi.clearAllMocks(); });
 
 describe("useContacts", () => {
+  // Verifies paginated contacts are fetched, returning the items array and total count.
+  // Essential for the contacts table to render rows and pagination controls.
   it("fetches paginated contacts, returns items and total", async () => {
     mockGet.mockResolvedValue({
       contacts: [

--- a/frontend/src/hooks/useDashboardThread.test.tsx
+++ b/frontend/src/hooks/useDashboardThread.test.tsx
@@ -32,6 +32,8 @@ beforeEach(() => {
 });
 
 describe("useDashboardThread", () => {
+  // Verifies that conversations and labels are fetched from the API on initial render.
+  // Ensures the hook triggers both conversation and label endpoints immediately.
   it("fetches conversations on mount", async () => {
     mockGet.mockImplementation((url: string) => {
       if (url.startsWith("/api/user/conversation-labels")) {
@@ -63,12 +65,16 @@ describe("useDashboardThread", () => {
     );
   });
 
+  // Confirms that loadingConversations starts as true before any fetch completes.
+  // Guarantees the UI can show a loading state immediately on mount.
   it("returns loadingConversations initially as true", () => {
     const { result } = renderDashboardThreadHook();
 
     expect(result.current.loadingConversations).toBe(true);
   });
 
+  // Ensures loadingConversations is set to false after both API calls resolve.
+  // Prevents the UI from showing an infinite loading state when data is available.
   it("sets loadingConversations to false after fetch completes", async () => {
     mockGet.mockImplementation((url: string) => {
       if (url.startsWith("/api/user/conversation-labels")) {
@@ -87,6 +93,8 @@ describe("useDashboardThread", () => {
     expect(result.current.loadingConversations).toBe(false);
   });
 
+  // Verifies that the hook subscribes to SSE realtime updates for the current workspace.
+  // Critical for live conversation updates without manual page refreshes.
   it("subscribes to realtime updates for the active workspace", () => {
     mockGet.mockResolvedValue({ labels: [], conversations: [] });
 

--- a/frontend/src/hooks/useIsWorkspaceOwner.test.tsx
+++ b/frontend/src/hooks/useIsWorkspaceOwner.test.tsx
@@ -25,6 +25,8 @@ function wrapper() {
 beforeEach(() => { vi.clearAllMocks(); });
 
 describe("useIsWorkspaceOwner", () => {
+  // Verifies that isOwner is true when the workspace API returns role "owner".
+  // Used to gate owner-only UI elements like workspace settings.
   it("returns true for owner role", async () => {
     mockGet.mockResolvedValue({ workspace: { role: "owner" } });
     const { result } = renderHook(() => useIsWorkspaceOwner(), { wrapper: wrapper() });
@@ -32,6 +34,8 @@ describe("useIsWorkspaceOwner", () => {
     expect(result.current.isOwner).toBe(true);
   });
 
+  // Verifies that isOwner is false when the workspace API returns a non-owner role.
+  // Ensures members cannot access owner-restricted functionality.
   it("returns false for member role", async () => {
     mockGet.mockResolvedValue({ workspace: { role: "member" } });
     const { result } = renderHook(() => useIsWorkspaceOwner(), { wrapper: wrapper() });

--- a/frontend/src/hooks/useProfileSettings.test.tsx
+++ b/frontend/src/hooks/useProfileSettings.test.tsx
@@ -25,6 +25,8 @@ function wrapper() {
 beforeEach(() => { vi.clearAllMocks(); });
 
 describe("useProfileSettings", () => {
+  // Verifies the hook fetches user and workspace profile data and sets loading=false when done.
+  // Ensures the settings page can display user info and workspace name after fetch completes.
   it("fetches and returns profile data", async () => {
     mockGet.mockResolvedValue({
       user: { id: "u1", email: "a@b.com", firstName: "John", lastName: "Doe" },

--- a/frontend/src/hooks/useRealtime.test.ts
+++ b/frontend/src/hooks/useRealtime.test.ts
@@ -51,6 +51,8 @@ afterEach(() => {
 });
 
 describe("useRealtime", () => {
+  // Verifies that an EventSource is opened with the correct workspaceId and token query params.
+  // Ensures SSE connections are scoped to the current workspace so only relevant events arrive.
   it("subscribes to SSE when workspaceId is provided", async () => {
     const onEvent = vi.fn();
 
@@ -65,6 +67,8 @@ describe("useRealtime", () => {
     expect(es.url).toContain("token=test-token");
   });
 
+  // Confirms that no EventSource is created when workspaceId is null/falsy.
+  // Prevents SSE connections from being opened before a workspace is selected.
   it("does not subscribe when workspaceId is null", () => {
     const onEvent = vi.fn();
 
@@ -73,6 +77,8 @@ describe("useRealtime", () => {
     expect(eventSourceInstances.length).toBe(0);
   });
 
+  // Verifies that the onEvent callback is invoked with parsed JSON when an SSE event arrives.
+  // Critical for live message updates: new messages must trigger UI refresh without page reload.
   it("calls onEvent when a 'message.created' SSE event arrives", async () => {
     const onEvent = vi.fn();
 
@@ -94,6 +100,8 @@ describe("useRealtime", () => {
     });
   });
 
+  // Confirms that the EventSource is closed when the component using the hook unmounts.
+  // Prevents memory leaks and dangling connections that could exhaust server resources.
   it("cleans up EventSource on unmount", async () => {
     const onEvent = vi.fn();
     const closeSpy = vi.spyOn(MockEventSource.prototype, "close");

--- a/frontend/src/hooks/useSkills.test.tsx
+++ b/frontend/src/hooks/useSkills.test.tsx
@@ -25,6 +25,8 @@ function wrapper() {
 beforeEach(() => { vi.clearAllMocks(); });
 
 describe("useSkills", () => {
+  // Confirms the hook fetches the skills list from the API and exposes it in the returned state.
+  // Ensures the agent setup page can display available workspace skills.
   it("fetches skills list", async () => {
     mockGet.mockResolvedValue({
       skills: [{ id: "s1", display_name: "My Skill", skill_key: "my_skill", description: "", is_active: true, storage_path: "", created_at: "2025-01-01", updated_at: "2025-01-01" }],

--- a/frontend/src/hooks/useTasks.test.ts
+++ b/frontend/src/hooks/useTasks.test.ts
@@ -37,6 +37,8 @@ afterEach(() => {
 });
 
 describe("useTasks", () => {
+  // Verifies tasks are fetched with pagination parameters and returned with total count.
+  // Critical for the tasks table to display rows and page controls correctly.
   it("fetches tasks with pagination", async () => {
     const query = { page: 1, search: "" };
     const { result } = renderHook(() => useTasks(query));
@@ -46,6 +48,8 @@ describe("useTasks", () => {
     expect(result.current.total).toBe(1);
   });
 
+  // Verifies that the hook silently polls for task status updates without showing a loading spinner.
+  // Ensures run status changes (e.g. pending → success) appear in the table without disruptive reloads.
   it("polls task list silently so run status updates without reloading the table", async () => {
     vi.useFakeTimers();
     const query = { page: 1, search: "" };

--- a/frontend/src/hooks/useTransientBooleanReset.test.ts
+++ b/frontend/src/hooks/useTransientBooleanReset.test.ts
@@ -7,6 +7,8 @@ beforeEach(() => { vi.useFakeTimers(); });
 afterEach(() => { vi.useRealTimers(); });
 
 describe("useTransientBooleanReset", () => {
+  // Verifies that setting the flag to true auto-resets it to false after the specified timeout.
+  // Ensures transient success banners and flash messages dismiss automatically instead of persisting.
   it("toggles and auto-resets after timeout", () => {
     const { result } = renderHook(() => {
       const [flag, setFlag] = useState(false);

--- a/frontend/src/lib/active-workspace.test.ts
+++ b/frontend/src/lib/active-workspace.test.ts
@@ -13,16 +13,22 @@ describe("getActiveWorkspaceId", () => {
     setActiveWorkspaceId("");
   });
 
+  // Verifies that setActiveWorkspaceId's value is returned directly when explicitly set.
+  // Ensures programmatic workspace overrides work correctly for the API client.
   it("returns explicitly set workspace id", () => {
     setActiveWorkspaceId("ws-explicit");
     expect(getActiveWorkspaceId()).toBe("ws-explicit");
   });
 
+  // Verifies fallback to URL path extraction when no explicit workspace ID is set.
+  // Needed so deep-linked pages automatically pick up the workspace from the URL.
   it("falls back to first URL segment on workspace routes", () => {
     window.history.replaceState({}, "", "/047be053-c7d9-4af4-b104-af8c9a019c0b/dashboard");
     expect(getActiveWorkspaceId()).toBe("047be053-c7d9-4af4-b104-af8c9a019c0b");
   });
 
+  // Confirms that public routes like /sign-in are not mistaken for workspace IDs.
+  // Prevents unauthenticated pages from incorrectly setting a workspace context.
   it("does not treat public routes as workspace ids", () => {
     window.history.replaceState({}, "", "/sign-in");
     expect(getActiveWorkspaceId()).toBe("");

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -36,6 +36,8 @@ afterEach(() => {
 
 describe("api client", () => {
   describe("Token handling", () => {
+    // Confirms the API client sends the access token in the Authorization header.
+    // Ensures every request is authenticated and the backend can identify the caller.
     it("attaches Authorization: Bearer header", async () => {
       mockFetch.mockResolvedValue({
         ok: true,
@@ -49,6 +51,8 @@ describe("api client", () => {
       expect(headers.Authorization).toBe("Bearer valid-token");
     });
 
+    // Confirms the API client sends the active workspace ID in the X-Workspace-Id header.
+    // Critical for multi-workspace scoping so the backend serves the correct workspace data.
     it("attaches X-Workspace-Id header", async () => {
       mockFetch.mockResolvedValue({
         ok: true,
@@ -64,6 +68,8 @@ describe("api client", () => {
   });
 
   describe("Token refresh on 401", () => {
+    // Verifies that a 401 response triggers a token refresh and retries the original request.
+    // Prevents users from being kicked out mid-session when their access token expires.
     it("auto-refreshes token on 401 and retries", async () => {
       mockFetch
         .mockResolvedValueOnce({
@@ -85,6 +91,8 @@ describe("api client", () => {
       expect(mockFetch).toHaveBeenCalledTimes(2);
     });
 
+    // Verifies that when both access and refresh tokens are invalid/null, the user is redirected to sign-in.
+    // Ensures the security boundary holds: no stale sessions linger after full token expiry.
     it("redirects to sign-in when both tokens are invalid", async () => {
       mockFetch.mockResolvedValue({
         ok: false,
@@ -102,6 +110,8 @@ describe("api client", () => {
   });
 
   describe("FormData handling", () => {
+    // Confirms that Content-Type is not set when sending FormData, letting the browser set it with the boundary.
+    // Prevents malformed multipart uploads that would fail on the server side.
     it("does not set Content-Type for FormData requests", async () => {
       mockFetch.mockResolvedValue({
         ok: true,
@@ -119,6 +129,8 @@ describe("api client", () => {
   });
 
   describe("workspaceId override", () => {
+    // Verifies that a per-request workspaceId override takes precedence over the active workspace.
+    // Needed for cross-workspace operations like admin tools that target a different workspace.
     it("uses provided workspaceId override", async () => {
       mockFetch.mockResolvedValue({
         ok: true,

--- a/frontend/src/lib/auth-client.test.ts
+++ b/frontend/src/lib/auth-client.test.ts
@@ -34,6 +34,7 @@ afterEach(() => {
 
 describe("auth-client", () => {
   describe("getAccessToken", () => {
+    // Verifies that saveAuthTokens persists access and refresh tokens to localStorage so getAccessToken can retrieve them later.
     it("reads tokens from localStorage", async () => {
       const { saveAuthTokens, getAccessToken } = await import("../lib/auth-client.js");
 
@@ -48,6 +49,7 @@ describe("auth-client", () => {
   });
 
   describe("saveAuthTokens", () => {
+    // Ensures both accessToken and refreshToken are written to localStorage under the senqo_auth key.
     it("writes access token to localStorage", async () => {
       const { saveAuthTokens } = await import("../lib/auth-client.js");
       saveAuthTokens("access-123", "refresh-456");
@@ -58,6 +60,7 @@ describe("auth-client", () => {
       expect(parsed.refreshToken).toBe("refresh-456");
     });
 
+    // Key behaviour: calling saveAuthTokens with only an access token must not wipe the already-stored refresh token.
     it("preserves existing refresh token when only passed access token", async () => {
       const { saveAuthTokens } = await import("../lib/auth-client.js");
       saveAuthTokens("access-123", "refresh-456");
@@ -71,6 +74,7 @@ describe("auth-client", () => {
   });
 
   describe("removeAuthTokens", () => {
+    // Verifies that removeAuthTokens deletes the entire senqo_auth entry from localStorage, clearing all session data.
     it("clears localStorage", async () => {
       const { saveAuthTokens, removeAuthTokens } = await import("../lib/auth-client.js");
       saveAuthTokens("access-123", "refresh-456");
@@ -81,6 +85,7 @@ describe("auth-client", () => {
   });
 
   describe("login", () => {
+    // Happy path: a successful login response returns accessToken, refreshToken, and user object from the API.
     it("returns auth payload on success", async () => {
       mockFetch.mockResolvedValue({
         ok: true,
@@ -100,6 +105,7 @@ describe("auth-client", () => {
       expect(result.user.id).toBe("user-1");
     });
 
+    // Error path: when the API returns ok:false with an error message, login must throw with that message.
     it("throws on error response", async () => {
       mockFetch.mockResolvedValue({
         ok: false,
@@ -112,6 +118,7 @@ describe("auth-client", () => {
   });
 
   describe("register", () => {
+    // Happy path: registering with email, password, and name returns tokens and user info from the backend.
     it("sends registration data and returns tokens", async () => {
       mockFetch.mockResolvedValue({
         ok: true,
@@ -130,6 +137,7 @@ describe("auth-client", () => {
       expect(result.user.email).toBe("new@example.com");
     });
 
+    // Error path: a failed registration (e.g. duplicate email) must throw the error message from the API.
     it("throws on registration error", async () => {
       mockFetch.mockResolvedValue({
         ok: false,
@@ -144,6 +152,7 @@ describe("auth-client", () => {
   });
 
   describe("logout", () => {
+    // Verifies that logout removes the auth tokens from localStorage after calling the logout API endpoint.
     it("clears tokens after calling logout endpoint", async () => {
       mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
       const { saveAuthTokens, logout } = await import("../lib/auth-client.js");

--- a/frontend/src/lib/custom-tool-test-input.test.ts
+++ b/frontend/src/lib/custom-tool-test-input.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from "vitest";
 import { DEFAULT_TOOL_TEST_INPUT, normalizeToolTestInput } from "@/lib/custom-tool-test-input";
 
 describe("normalizeToolTestInput → uses stored JSON or default", () => {
+  // When no stored test input exists (empty string or undefined), the function must return the default template JSON.
   it("returns default when stored value is empty", () => {
     expect(normalizeToolTestInput("")).toBe(DEFAULT_TOOL_TEST_INPUT);
     expect(normalizeToolTestInput(undefined)).toBe(DEFAULT_TOOL_TEST_INPUT);
   });
 
+  // When a stored value exists, it must be returned trimmed so leading/trailing whitespace doesn't interfere.
   it("returns trimmed stored value when present", () => {
     expect(normalizeToolTestInput('{ "status": "new" }')).toBe('{ "status": "new" }');
   });

--- a/frontend/src/lib/public-tasks-api.test.ts
+++ b/frontend/src/lib/public-tasks-api.test.ts
@@ -10,6 +10,7 @@ describe("getPublicTasksApiUrl", () => {
     vi.unstubAllGlobals();
   });
 
+  // In production (app.senqo.app), the public tasks API URL must point to the dedicated api.senqo.app host.
   it("returns production API host when app runs on senqo.app", () => {
     vi.stubGlobal("window", {
       location: {
@@ -22,6 +23,7 @@ describe("getPublicTasksApiUrl", () => {
     expect(getPublicTasksApiUrl()).toBe("https://api.senqo.app/api/tasks");
   });
 
+  // In local dev (localhost), the URL must be same-origin so it works without CORS issues.
   it("returns same-origin API path for local development", () => {
     vi.stubGlobal("window", {
       location: {
@@ -36,6 +38,7 @@ describe("getPublicTasksApiUrl", () => {
 });
 
 describe("buildCreateTaskRequestBody", () => {
+  // The request body must include all fields required by the API: message, sender, recipient, schedule type, timestamp, and timezone.
   it("includes one_time schedule fields required by the API", () => {
     expect(
       buildCreateTaskRequestBody({
@@ -57,6 +60,7 @@ describe("buildCreateTaskRequestBody", () => {
 });
 
 describe("buildCreateTaskCurlExample", () => {
+  // The generated curl example must contain the resolved API URL, the API key header, and the scheduleType payload.
   it("embeds the resolved URL and API key in a copy-ready curl command", () => {
     vi.stubGlobal("window", {
       location: {

--- a/frontend/src/pages/auth/SignIn.test.tsx
+++ b/frontend/src/pages/auth/SignIn.test.tsx
@@ -45,28 +45,33 @@ describe("SignInPage", () => {
     ]);
   });
 
+  // Smoke test: the sign-in form must render email and password input fields so users can enter credentials.
   it("renders email and password fields", () => {
     render(<SignInPage />);
     expect(screen.getByLabelText("Email")).toBeInTheDocument();
     expect(screen.getByLabelText("Password")).toBeInTheDocument();
   });
 
+  // The page must display the "Welcome back" heading to give users clear context on the sign-in page.
   it("shows Welcome back heading", () => {
     render(<SignInPage />);
     expect(screen.getByText("Welcome back")).toBeInTheDocument();
   });
 
+  // The primary call-to-action "Sign in" button must be rendered and accessible by role.
   it("shows Sign in button", () => {
     render(<SignInPage />);
     expect(screen.getByRole("button", { name: "Sign in" })).toBeInTheDocument();
   });
 
+  // The "Create an account" link must point to /sign-up so new users can navigate to registration.
   it('renders New to Senqo? link pointing to /sign-up', () => {
     render(<SignInPage />);
     const link = screen.getByRole("link", { name: "Create an account" });
     expect(link).toHaveAttribute("href", "/sign-up");
   });
 
+  // When redirected with an error query param, the page must display that error message to the user.
   it("shows error message when search params contain error", () => {
     mockUseSearchParams.mockReturnValue([
       new URLSearchParams({ error: "Invalid credentials" }),
@@ -77,6 +82,7 @@ describe("SignInPage", () => {
     expect(screen.getByText("Invalid credentials")).toBeInTheDocument();
   });
 
+  // Full flow: submitting valid credentials calls login, persists tokens, and navigates to the dashboard.
   it("calls login on form submit and navigates on success", async () => {
     const user = userEvent.setup();
     mockLogin.mockResolvedValue({ accessToken: "at", refreshToken: "rt" });

--- a/frontend/src/pages/auth/SignUp.test.tsx
+++ b/frontend/src/pages/auth/SignUp.test.tsx
@@ -40,6 +40,7 @@ describe("SignUpPage", () => {
     vi.clearAllMocks();
   });
 
+  // Smoke test: the sign-up form must render name, email, and password fields for user registration.
   it("renders name, email, and password fields", () => {
     render(<SignUpPage />);
     expect(screen.getByLabelText("Name")).toBeInTheDocument();
@@ -47,22 +48,26 @@ describe("SignUpPage", () => {
     expect(screen.getByLabelText("Password")).toBeInTheDocument();
   });
 
+  // The page must display the "Create your account" heading to indicate the purpose of the form.
   it("shows Create your account heading", () => {
     render(<SignUpPage />);
     expect(screen.getByText("Create your account")).toBeInTheDocument();
   });
 
+  // The primary "Create account" button must be rendered and accessible for form submission.
   it("shows Create account button", () => {
     render(<SignUpPage />);
     expect(screen.getByRole("button", { name: "Create account" })).toBeInTheDocument();
   });
 
+  // The "Sign in" link for existing users must point to /sign-in for easy navigation.
   it('renders Already have an account? link to /sign-in', () => {
     render(<SignUpPage />);
     const link = screen.getByRole("link", { name: "Sign in" });
     expect(link).toHaveAttribute("href", "/sign-in");
   });
 
+  // Full flow: submitting the registration form calls the register API, saves tokens, and navigates to the dashboard.
   it("calls register on form submit and navigates on success", async () => {
     const user = userEvent.setup();
     mockRegister.mockResolvedValue({ accessToken: "at", refreshToken: "rt" });

--- a/frontend/src/pages/dashboard/components/confirm-destructive-dialog.test.tsx
+++ b/frontend/src/pages/dashboard/components/confirm-destructive-dialog.test.tsx
@@ -24,6 +24,7 @@ vi.mock("@/components/ui/dialog", () => ({
 import { ConfirmDestructiveDialog } from "./confirm-destructive-dialog";
 
 describe("confirm-destructive-dialog", () => {
+  // When open, the dialog must render the title, description text, and a confirm button with the given label.
   it("opens and shows title and confirm button", () => {
     render(
       <ConfirmDestructiveDialog
@@ -42,6 +43,7 @@ describe("confirm-destructive-dialog", () => {
     expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
   });
 
+  // Clicking the confirm button must invoke the onConfirm callback so the destructive action proceeds.
   it("calls onConfirm when confirm button clicked", async () => {
     const user = userEvent.setup();
     const onConfirm = vi.fn().mockResolvedValue(undefined);
@@ -61,6 +63,7 @@ describe("confirm-destructive-dialog", () => {
     expect(onConfirm).toHaveBeenCalled();
   });
 
+  // While confirming (isConfirming=true), the button label switches to the pendingConfirmLabel for user feedback.
   it("shows pendingConfirmLabel when isConfirming is true", () => {
     render(
       <ConfirmDestructiveDialog

--- a/frontend/src/pages/dashboard/components/table-pagination.test.tsx
+++ b/frontend/src/pages/dashboard/components/table-pagination.test.tsx
@@ -4,6 +4,7 @@ import { vi } from "vitest";
 import { TablePagination } from "./table-pagination";
 
 describe("table-pagination", () => {
+  // The pagination component must render both Previous and Next navigation buttons.
   it("renders Previous and Next buttons", () => {
     render(
       <TablePagination page={2} total={50} pageSize={10} onPage={vi.fn()} />,
@@ -12,6 +13,7 @@ describe("table-pagination", () => {
     expect(screen.getByRole("button", { name: "Next" })).toBeInTheDocument();
   });
 
+  // The component must show the current range and total, e.g. "Showing 1–10 of 25" for page 1 with pageSize 10.
   it("shows correct page info", () => {
     render(
       <TablePagination page={1} total={25} pageSize={10} onPage={vi.fn()} />,
@@ -19,6 +21,7 @@ describe("table-pagination", () => {
     expect(screen.getByText("Showing 1–10 of 25")).toBeInTheDocument();
   });
 
+  // Clicking Next must call onPage with the next page number (page + 1).
   it("calls onPage when Next button clicked", async () => {
     const user = userEvent.setup();
     const onPage = vi.fn();
@@ -29,6 +32,7 @@ describe("table-pagination", () => {
     expect(onPage).toHaveBeenCalledWith(2);
   });
 
+  // Clicking Previous must call onPage with the previous page number (page - 1).
   it("calls onPage when Previous button clicked", async () => {
     const user = userEvent.setup();
     const onPage = vi.fn();
@@ -39,6 +43,7 @@ describe("table-pagination", () => {
     expect(onPage).toHaveBeenCalledWith(2);
   });
 
+  // The Previous button must be disabled when already on the first page to prevent going below page 1.
   it("disables Previous on first page", () => {
     render(
       <TablePagination page={1} total={50} pageSize={10} onPage={vi.fn()} />,

--- a/whatsapp/src/jid-resolve.test.ts
+++ b/whatsapp/src/jid-resolve.test.ts
@@ -26,6 +26,7 @@ vi.mock("../src/logger.js", () => ({
 }));
 
 describe("jid resolution", () => {
+  // When a messageKey provides remoteJidAlt, the LID must resolve to the phone-number JID from remoteJidAlt.
   it("resolves LID to phone-number JID when remoteJidAlt is available", async () => {
     const { learnFromMessageKey, resolveToPn, clearConnectionLidState } = await import("../src/jid.js");
     clearConnectionLidState("conn-jid");
@@ -37,6 +38,7 @@ describe("jid resolution", () => {
     expect(result.jid).toBe("1234567890@s.whatsapp.net");
   });
 
+  // When a contact roster entry provides lid and phoneNumber, the LID must resolve via the contact's phone number.
   it("resolves LID via contact roster lookup", async () => {
     const { learnFromContact, resolveToPn, clearConnectionLidState } = await import("../src/jid.js");
     clearConnectionLidState("conn-contact");
@@ -50,6 +52,7 @@ describe("jid resolution", () => {
     expect(result.jid).toBe("9876543210@s.whatsapp.net");
   });
 
+  // When no mapping exists for a LID, the function must fall back to returning the LID itself as the JID.
   it("falls back to LID-only chatId when no mapping exists", async () => {
     const { resolveToPn, clearConnectionLidState } = await import("../src/jid.js");
     clearConnectionLidState("conn-nomap");

--- a/whatsapp/src/jid.test.ts
+++ b/whatsapp/src/jid.test.ts
@@ -29,10 +29,12 @@ const jid = await import("../src/jid.js");
 
 describe("jid", () => {
   describe("isLidJid", () => {
+    // JIDs ending with @lid must be recognised as LID JIDs for LID-to-PN resolution.
     it("returns true for LID JIDs", () => {
       expect(jid.isLidJid("123456@lid")).toBe(true);
     });
 
+    // Standard user JIDs, group JIDs, null, and undefined must not be classified as LID JIDs.
     it("returns false for non-LID JIDs", () => {
       expect(jid.isLidJid("123456@s.whatsapp.net")).toBe(false);
       expect(jid.isLidJid("123456789@g.us")).toBe(false);
@@ -42,20 +44,24 @@ describe("jid", () => {
   });
 
   describe("isGroupJid", () => {
+    // JIDs ending with @g.us must be classified as group JIDs for group-specific message handling.
     it("returns true for group JIDs", () => {
       expect(jid.isGroupJid("123456789@g.us")).toBe(true);
     });
 
+    // A standard user JID (s.whatsapp.net) must not be misclassified as a group JID.
     it("returns false for user JIDs", () => {
       expect(jid.isGroupJid("123456@s.whatsapp.net")).toBe(false);
     });
   });
 
   describe("isBroadcastJid", () => {
+    // The status@broadcast JID must be classified as a broadcast JID to filter broadcast messages.
     it("returns true for broadcast JIDs", () => {
       expect(jid.isBroadcastJid("status@broadcast")).toBe(true);
     });
 
+    // LID JIDs and null must not be classified as broadcast JIDs.
     it("returns false for non-broadcast JIDs", () => {
       expect(jid.isBroadcastJid("123@lid")).toBe(false);
       expect(jid.isBroadcastJid(null)).toBe(false);
@@ -63,10 +69,12 @@ describe("jid", () => {
   });
 
   describe("isNewsletterJid", () => {
+    // JIDs ending with @newsletter (channel JIDs) must be classified as newsletter JIDs.
     it("returns true for channel JIDs", () => {
       expect(jid.isNewsletterJid("120363123456789012@newsletter")).toBe(true);
     });
 
+    // Standard user JIDs and null must not be classified as newsletter/channel JIDs.
     it("returns false for non-channel JIDs", () => {
       expect(jid.isNewsletterJid("123456@s.whatsapp.net")).toBe(false);
       expect(jid.isNewsletterJid(null)).toBe(false);
@@ -74,11 +82,13 @@ describe("jid", () => {
   });
 
   describe("isIngestableDmChatJid", () => {
+    // User DM JIDs (s.whatsapp.net and lid) must be marked as ingestable for conversation tracking.
     it("returns true for user DMs", () => {
       expect(jid.isIngestableDmChatJid("123456@s.whatsapp.net")).toBe(true);
       expect(jid.isIngestableDmChatJid("123456@lid")).toBe(true);
     });
 
+    // Groups, newsletters, broadcasts, and empty strings must not be ingestable as DM chats.
     it("returns false for groups, channels, and broadcasts", () => {
       expect(jid.isIngestableDmChatJid("123456789@g.us")).toBe(false);
       expect(jid.isIngestableDmChatJid("120363123456789012@newsletter")).toBe(false);
@@ -88,52 +98,63 @@ describe("jid", () => {
   });
 
   describe("isUserJid", () => {
+    // s.whatsapp.net JIDs represent phone-number-based users and must be classified as user JIDs.
     it("returns true for s.whatsapp.net JIDs", () => {
       expect(jid.isUserJid("123456789@s.whatsapp.net")).toBe(true);
     });
 
+    // c.us JIDs (common user suffix in Baileys) must also be classified as user JIDs.
     it("returns true for c.us JIDs", () => {
       expect(jid.isUserJid("123456789@c.us")).toBe(true);
     });
 
+    // LID JIDs must be classified as user JIDs since they represent individual users.
     it("returns true for LID JIDs", () => {
       expect(jid.isUserJid("123456@lid")).toBe(true);
     });
 
+    // Group JIDs (g.us) must not be classified as user JIDs.
     it("returns false for group JIDs", () => {
       expect(jid.isUserJid("123@g.us")).toBe(false);
     });
 
+    // Null input must safely return false rather than throwing.
     it("returns false for null input", () => {
       expect(jid.isUserJid(null)).toBe(false);
     });
   });
 
   describe("jidDigits", () => {
+    // Extracts only the numeric portion from a standard s.whatsapp.net JID.
     it("extracts digits from a JID", () => {
       expect(jid.jidDigits("123456789@s.whatsapp.net")).toBe("123456789");
     });
 
+    // Device suffixes like :42 must be stripped so only the base phone number digits remain.
     it("drops device suffix", () => {
       expect(jid.jidDigits("123456789:42@s.whatsapp.net")).toBe("123456789");
     });
 
+    // Raw phone numbers with formatting characters (spaces, parens, dashes) must be stripped to digits only.
     it("strips non-digit characters from raw phone numbers", () => {
       expect(jid.jidDigits("+1 (234) 567-890")).toBe("1234567890");
     });
   });
 
   describe("normalizeJid", () => {
+    // Null input must return an empty string instead of crashing.
     it("returns empty string for null input", () => {
       expect(jid.normalizeJid(null)).toBe("");
     });
 
+    // Undefined input must return an empty string instead of crashing.
     it("returns empty string for undefined input", () => {
       expect(jid.normalizeJid(undefined)).toBe("");
     });
   });
 
   describe("learnMapping", () => {
+    // learnMapping must establish a bidirectional LID-to-phone-number mapping so resolveToPn can find it later.
     it("learns a LID <-> PN mapping", () => {
       jid.clearConnectionLidState("conn-1");
       jid.learnMapping("conn-1", "123@lid", "123456789@s.whatsapp.net");
@@ -141,6 +162,7 @@ describe("jid", () => {
       expect(result.jid).toBe("123456789@s.whatsapp.net");
     });
 
+    // Passing a non-LID JID as the first argument must be silently ignored, leaving the original JID unchanged.
     it("ignores non-LID JIDs as the first argument", () => {
       jid.clearConnectionLidState("conn-x");
       jid.learnMapping("conn-x", "not-lid@s.whatsapp.net", "123456789@s.whatsapp.net");
@@ -150,16 +172,19 @@ describe("jid", () => {
   });
 
   describe("resolveToPn", () => {
+    // A non-LID JID (already a phone-number JID) must be returned unchanged since no resolution is needed.
     it("returns the JID unchanged for non-LID JIDs", () => {
       const result = jid.resolveToPn("conn-2", "123456789@s.whatsapp.net");
       expect(result.jid).toBe("123456789@s.whatsapp.net");
     });
 
+    // Null input must return an empty string JID rather than throwing for safety.
     it("returns empty string for null JID", () => {
       const result = jid.resolveToPn("conn-2", null);
       expect(result.jid).toBe("");
     });
 
+    // When no mapping is found, the LID itself must be returned as both jid and lid fields.
     it("falls back to LID when no mapping exists", () => {
       const result = jid.resolveToPn("conn-2", "999999@lid");
       expect(result.jid).toBe("999999@lid");
@@ -168,6 +193,7 @@ describe("jid", () => {
   });
 
   describe("learnFromMessageKey", () => {
+    // A message key with remoteJid and remoteJidAlt must teach the resolver the LID-to-PN mapping.
     it("learns remoteJid <-> remoteJidAlt mapping", () => {
       jid.clearConnectionLidState("conn-msg");
       jid.learnFromMessageKey("conn-msg", {
@@ -178,6 +204,7 @@ describe("jid", () => {
       expect(result.jid).toBe("1234567890@s.whatsapp.net");
     });
 
+    // A null message key must not throw — the function must handle the edge case gracefully.
     it("handles null key gracefully", () => {
       jid.clearConnectionLidState("conn-null");
       expect(() => jid.learnFromMessageKey("conn-null", null)).not.toThrow();
@@ -185,6 +212,7 @@ describe("jid", () => {
   });
 
   describe("resolveToPn", () => {
+    // After learning a mapping, resolveToPn must return the phone-number JID and include the original LID.
     it("resolves LID to phone-number JID when mapping exists", () => {
       jid.clearConnectionLidState("conn-r");
       jid.learnMapping("conn-r", "222@lid", "9876543210@s.whatsapp.net");
@@ -195,10 +223,12 @@ describe("jid", () => {
   });
 
   describe("phoneToUserJid", () => {
+    // Raw phone digits must be converted to a full s.whatsapp.net JID for message sending.
     it("converts phone digits to JID", () => {
       expect(jid.phoneToUserJid("1234567890")).toBe("1234567890@s.whatsapp.net");
     });
 
+    // A group JID passed to phoneToUserJid must be returned as-is since it's already a valid JID.
     it("returns group JID unchanged", () => {
       const gid = "123456789@g.us";
       expect(jid.phoneToUserJid(gid)).toBe(gid);
@@ -206,10 +236,12 @@ describe("jid", () => {
   });
 
   describe("toSendableJid", () => {
+    // A chat ID (raw phone digits) must be converted to a sendable s.whatsapp.net JID.
     it("converts chat id to user JID", () => {
       expect(jid.toSendableJid("1234567890")).toBe("1234567890@s.whatsapp.net");
     });
 
+    // A group JID passed to toSendableJid must be returned as-is since it's already sendable.
     it("returns group JID unchanged", () => {
       const gid = "123456789@g.us";
       expect(jid.toSendableJid(gid)).toBe(gid);
@@ -217,6 +249,7 @@ describe("jid", () => {
   });
 
   describe("learnFromContact", () => {
+    // A WhatsApp contact with both lid and phoneNumber must be learned so LID resolves to that phone number.
     it("learns from contact with phoneNumber and lid", () => {
       jid.clearConnectionLidState("conn-contact");
       jid.learnFromContact("conn-contact", {
@@ -231,11 +264,13 @@ describe("jid", () => {
   });
 
   describe("getContactPnByLid", () => {
+    // Querying a LID that was never learned must return undefined rather than throwing.
     it("returns undefined for unknown LID", () => {
       const result = jid.getContactPnByLid("conn-unknown", "nonexistent@lid");
       expect(result).toBeUndefined();
     });
 
+    // After learnFromContact stores the mapping, getContactPnByLid must return the phone number JID.
     it("returns PN after learning from contact", () => {
       jid.clearConnectionLidState("conn-contact-2");
       jid.learnFromContact("conn-contact-2", {
@@ -250,6 +285,7 @@ describe("jid", () => {
   });
 
   describe("lidLookupFactory", () => {
+    // The factory must create a lookup function that resolves known LIDs to PNs and returns undefined for unknowns.
     it("creates a lookup function that finds learned mappings", () => {
       jid.clearConnectionLidState("conn-lookup");
       jid.learnFromContact("conn-lookup", {

--- a/whatsapp/src/message-dedupe.test.ts
+++ b/whatsapp/src/message-dedupe.test.ts
@@ -3,11 +3,13 @@ import { MessageDedupeTracker, webhookDedupeKey } from "../src/message-dedupe.js
 
 describe("message-dedupe", () => {
   describe("webhookDedupeKey", () => {
+    // Inbound messages must be prefixed with "message.inbound:" to namespace the key correctly.
     it("formats inbound key correctly", () => {
       const key = webhookDedupeKey(false, "msg-123");
       expect(key).toBe("message.inbound:msg-123");
     });
 
+    // Outbound mirrors must be prefixed with "message.outbound_mirror:" to distinguish from real inbound messages.
     it("formats outbound mirror key correctly", () => {
       const key = webhookDedupeKey(true, "msg-456");
       expect(key).toBe("message.outbound_mirror:msg-456");
@@ -16,11 +18,13 @@ describe("message-dedupe", () => {
 
   describe("MessageDedupeTracker", () => {
     describe("tryAcquire", () => {
+      // A key that has never been seen must be acquirable on the first attempt.
       it("returns true for a new key", () => {
         const tracker = new MessageDedupeTracker();
         expect(tracker.tryAcquire("key-1")).toBe(true);
       });
 
+      // Once a key has been acquired, a second attempt must return false to prevent duplicate processing.
       it("returns false for a duplicate key", () => {
         const tracker = new MessageDedupeTracker();
         tracker.tryAcquire("key-1");
@@ -29,6 +33,7 @@ describe("message-dedupe", () => {
     });
 
     describe("markDelivered", () => {
+      // Marking a key as delivered must continue to reject duplicates even after delivery confirmation.
       it("marks key as delivered so duplicates are rejected", () => {
         const tracker = new MessageDedupeTracker();
         tracker.tryAcquire("key-1");
@@ -36,6 +41,7 @@ describe("message-dedupe", () => {
         expect(tracker.tryAcquire("key-1")).toBe(false);
       });
 
+      // A delivered key must be removed from inflight tracking so duplicates are still blocked by the delivered set.
       it("keeps the key out of inflight after delivery", () => {
         const tracker = new MessageDedupeTracker();
         tracker.tryAcquire("key-1");
@@ -45,6 +51,7 @@ describe("message-dedupe", () => {
     });
 
     describe("release", () => {
+      // Releasing a key must allow it to be re-acquired, e.g. after a processing failure.
       it("removes key from inflight so it can be re-acquired", () => {
         const tracker = new MessageDedupeTracker();
         tracker.tryAcquire("key-1");
@@ -54,6 +61,7 @@ describe("message-dedupe", () => {
     });
 
     describe("TTL expiry", () => {
+      // Verifies basic behaviour around TTL expiry: delivered keys remain rejected until the 7-day sweep.
       it("sweeps old delivered keys after 7 days", () => {
         const tracker = new MessageDedupeTracker();
         tracker.tryAcquire("key-1");

--- a/whatsapp/src/message-ingest.test.ts
+++ b/whatsapp/src/message-ingest.test.ts
@@ -28,6 +28,7 @@ vi.mock("../src/logger.js", () => ({
 const { shouldIngestBaileysMessage } = await import("./message-ingest.js");
 
 describe("shouldIngestBaileysMessage", () => {
+  // Channel (newsletter) messages must not be ingested since they are not user conversations.
   it("returns false for channel messages", () => {
     expect(
       shouldIngestBaileysMessage({
@@ -37,6 +38,7 @@ describe("shouldIngestBaileysMessage", () => {
     ).toBe(false);
   });
 
+  // Direct user messages from s.whatsapp.net must be ingested for conversation tracking.
   it("returns true for direct user messages", () => {
     expect(
       shouldIngestBaileysMessage({

--- a/whatsapp/src/session-manager.test.ts
+++ b/whatsapp/src/session-manager.test.ts
@@ -42,12 +42,14 @@ const { getOrCreate, startSession, removeSession, get } = await import("../src/s
 
 describe("session-manager", () => {
   describe("getOrCreate", () => {
+    // Calling getOrCreate twice with the same connectionId must return the identical session instance.
     it("returns same instance for same connectionId", () => {
       const s1 = getOrCreate("conn-1");
       const s2 = getOrCreate("conn-1");
       expect(s1).toBe(s2);
     });
 
+    // Calling getOrCreate with two different connectionIds must return distinct session instances.
     it("creates new instance for new connectionId", () => {
       const s1 = getOrCreate("conn-1");
       const s2 = getOrCreate("conn-2");
@@ -56,12 +58,14 @@ describe("session-manager", () => {
   });
 
   describe("startSession", () => {
+    // Calling startSession twice for the same connectionId must be safe (idempotent) and not throw.
     it("is idempotent when called twice", async () => {
       mockStart.mockResolvedValue(undefined);
       await startSession("conn-start");
       await startSession("conn-start");
     });
 
+    // startSession must return the session object after creating and starting it.
     it("returns the session after starting", async () => {
       mockStart.mockResolvedValue(undefined);
       const session = await startSession("conn-start-2");
@@ -70,6 +74,7 @@ describe("session-manager", () => {
   });
 
   describe("removeSession", () => {
+    // removeSession must call destroy on the session and then delete it from the internal map.
     it("calls destroy and removes from map", async () => {
       mockDestroy.mockResolvedValue(undefined);
       getOrCreate("conn-rm");
@@ -80,6 +85,7 @@ describe("session-manager", () => {
   });
 
   describe("get", () => {
+    // Getting a connectionId that was never created must return undefined rather than throwing.
     it("returns undefined for unknown connectionId", () => {
       expect(get("nonexistent")).toBeUndefined();
     });


### PR DESCRIPTION
## What & why

Added a preceding `//` comment to every `it()`/`test()` call across all 65 test files (309 test cases total). Each comment explains **what** is being tested, the **expected outcome**, and **why** the test exists.

This enforces **principle 17** in AGENTS.md — anyone reading a test file should understand its purpose without deciphering the assertions.

## User impact

None — comments-only change, no logic modified.

## Migrations

None.

## Tests affected

All 66 test files (65 actual test files + AGENTS.md). Every `npm run test` result should be identical — only comments were added.

## How to verify

1. Spot-check any `*.test.ts` file — every `it(`/`test(` has a `//` comment on the line before it
2. `npm run build` passes cleanly
3. `npm run test` output unchanged