### PR TITLE
feat: Remove hardcoded api host for backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,8 @@ NODE_ENV=production
 
 # Public URL — HTTPS on VPS; see README for Caddy setup
 FRONTEND_URL=https://<VPS_PUBLIC_IP>
+# Optional public API host for POST /api/tasks (hostname or URL). Falls back to FRONTEND_URL when unset.
+API_URL=
 AUTH_COOKIE_SECURE=true
 ALLOWED_PRODUCTION_ORIGINS=<VPS_PUBLIC_IP>
 DEV_FRONTEND_PORT=8080

--- a/backend/src/lib/public-api-host.test.ts
+++ b/backend/src/lib/public-api-host.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { normalizePublicApiHostname, resolvePublicApiAllowedHosts } from "./public-api-host.js";
+
+describe("normalizePublicApiHostname", () => {
+  // Full HTTPS URL → extract hostname only for host-guard comparisons.
+  it("strips scheme and path from URLs", () => {
+    expect(normalizePublicApiHostname("https://demo-app.senqo.app/")).toBe("demo-app.senqo.app");
+  });
+
+  // Hostname with port → compare on hostname without port.
+  it("strips port from host:port values", () => {
+    expect(normalizePublicApiHostname("demo-app.senqo.app:443")).toBe("demo-app.senqo.app");
+  });
+});
+
+describe("resolvePublicApiAllowedHosts", () => {
+  // API_URL set → use it and ignore FRONTEND_URL fallback.
+  it("prefers API_URL over FRONTEND_URL", () => {
+    expect(
+      resolvePublicApiAllowedHosts("api.example.com", "https://app.example.com"),
+    ).toEqual(["api.example.com"]);
+  });
+
+  // API_URL unset → fall back to FRONTEND_URL hostname.
+  it("falls back to FRONTEND_URL when API_URL is unset", () => {
+    expect(resolvePublicApiAllowedHosts(undefined, "https://demo-app.senqo.app")).toEqual([
+      "demo-app.senqo.app",
+    ]);
+  });
+
+  // API_URL supports comma-separated hostnames for multi-host deployments.
+  it("parses comma-separated API_URL hostnames", () => {
+    expect(resolvePublicApiAllowedHosts("a.example.com,b.example.com", undefined)).toEqual([
+      "a.example.com",
+      "b.example.com",
+    ]);
+  });
+
+  // Neither env var yields hosts → production guard blocks all hosts until configured.
+  it("returns empty list when API_URL and FRONTEND_URL are unset", () => {
+    expect(resolvePublicApiAllowedHosts("", "")).toEqual([]);
+  });
+});

--- a/backend/src/lib/public-api-host.ts
+++ b/backend/src/lib/public-api-host.ts
@@ -1,0 +1,45 @@
+export function normalizePublicApiHostname(input: string): string {
+  const trimmed = input.trim().toLowerCase();
+  if (!trimmed) {
+    return "";
+  }
+
+  try {
+    if (trimmed.includes("://")) {
+      return new URL(trimmed).hostname;
+    }
+  } catch {
+    // Fall through to hostname-only parsing.
+  }
+
+  const withoutPort = trimmed.split(":")[0]?.trim() ?? "";
+  if (!withoutPort) {
+    return "";
+  }
+  return withoutPort.endsWith(".") ? withoutPort.slice(0, -1) : withoutPort;
+}
+
+function parseHostnameList(raw: string): string[] {
+  const hosts: string[] = [];
+  for (const part of raw.split(",")) {
+    const host = normalizePublicApiHostname(part);
+    if (host) {
+      hosts.push(host);
+    }
+  }
+  return hosts;
+}
+
+/** Hostnames allowed for POST /api/tasks in production. API_URL wins; else FRONTEND_URL hostname. */
+export function resolvePublicApiAllowedHosts(
+  apiUrl: string | undefined,
+  frontendUrl: string | undefined,
+): string[] {
+  const fromApiUrl = parseHostnameList(apiUrl ?? "");
+  if (fromApiUrl.length > 0) {
+    return fromApiUrl;
+  }
+
+  const fromFrontend = normalizePublicApiHostname(frontendUrl ?? "");
+  return fromFrontend ? [fromFrontend] : [];
+}

--- a/backend/src/middleware/api-host-guard.test.ts
+++ b/backend/src/middleware/api-host-guard.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const { apiHostGuardMiddleware } = await import("../middleware/api-host-guard.js");
 
@@ -14,28 +14,80 @@ function mockContext(host: string | null, forwardedHost: string | null = null) {
   return { req: { header }, json } as unknown as Parameters<typeof apiHostGuardMiddleware>[0];
 }
 
-beforeEach(() => { vi.clearAllMocks(); });
-
 describe("apiHostGuardMiddleware", () => {
-  // Host matches allowed list → middleware calls next() without blocking the request, needed to ensure valid API hosts are not rejected.
-  it("allows when host matches PUBLIC_API_ALLOWED_HOSTS", async () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  // API_URL set → matching host passes in production.
+  it("allows when host matches API_URL", async () => {
     vi.stubEnv("NODE_ENV", "production");
-    vi.stubEnv("PUBLIC_API_ALLOWED_HOSTS", "api.example.com");
-    const c = mockContext("api.example.com");
+    vi.stubEnv("API_URL", "demo-app.senqo.app");
+    vi.stubEnv("FRONTEND_URL", "https://other.example.com");
+    const c = mockContext("demo-app.senqo.app");
     const next = vi.fn();
     await apiHostGuardMiddleware(c, next);
     expect(next).toHaveBeenCalled();
   });
 
-  // Host is not in the allow list → middleware returns 403 and stops the request, needed to verify unauthorized hosts are blocked in production.
-  it("denies (403) when host not allowed in production", async () => {
+  // API_URL unset → FRONTEND_URL hostname is allowed.
+  it("allows when API_URL is unset and host matches FRONTEND_URL", async () => {
     vi.stubEnv("NODE_ENV", "production");
-    vi.stubEnv("PUBLIC_API_ALLOWED_HOSTS", "api.example.com");
-    const c = mockContext("evil.com");
+    vi.stubEnv("API_URL", "");
+    vi.stubEnv("FRONTEND_URL", "https://demo-app.senqo.app");
+    const c = mockContext("demo-app.senqo.app");
+    const next = vi.fn();
+    await apiHostGuardMiddleware(c, next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  // API_URL takes precedence over FRONTEND_URL fallback.
+  it("prefers API_URL over FRONTEND_URL", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("API_URL", "api.example.com");
+    vi.stubEnv("FRONTEND_URL", "https://app.example.com");
+    const c = mockContext("app.example.com");
     const next = vi.fn();
     const response = await apiHostGuardMiddleware(c, next);
     expect(response).toBeDefined();
     expect((response as Response).status).toBe(403);
     expect(next).not.toHaveBeenCalled();
+  });
+
+  // Host not on allow list → 403 forbidden_host.
+  it("denies (403) when host not allowed in production", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("API_URL", "demo-app.senqo.app");
+    vi.stubEnv("FRONTEND_URL", "https://demo-app.senqo.app");
+    const c = mockContext("evil.com");
+    const next = vi.fn();
+    const response = await apiHostGuardMiddleware(c, next);
+    expect((response as Response).status).toBe(403);
+    await expect((response as Response).json()).resolves.toEqual({
+      ok: false,
+      error: "forbidden_host",
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  // Non-production → host guard is skipped.
+  it("allows any host when NODE_ENV is not production", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("API_URL", "");
+    vi.stubEnv("FRONTEND_URL", "");
+    const c = mockContext("evil.com");
+    const next = vi.fn();
+    await apiHostGuardMiddleware(c, next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  // Reverse proxy forwards public host via x-forwarded-host.
+  it("uses x-forwarded-host when present", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("API_URL", "demo-app.senqo.app");
+    const c = mockContext("internal", "demo-app.senqo.app");
+    const next = vi.fn();
+    await apiHostGuardMiddleware(c, next);
+    expect(next).toHaveBeenCalled();
   });
 });

--- a/backend/src/middleware/api-host-guard.ts
+++ b/backend/src/middleware/api-host-guard.ts
@@ -1,40 +1,25 @@
 import type { Context, Next } from "hono";
-
-const CANONICAL_PRODUCTION_API_HOST = "api.senqo.app";
-
-function normalizeHost(host: string): string {
-  const trimmed = host.trim().toLowerCase();
-  if (!trimmed) {
-    return "";
-  }
-  return trimmed.endsWith(".") ? trimmed.slice(0, -1) : trimmed;
-}
+import {
+  normalizePublicApiHostname,
+  resolvePublicApiAllowedHosts,
+} from "../lib/public-api-host.js";
 
 function resolveRequestHost(c: Context): string {
   const forwardedHost = c.req.header("x-forwarded-host")?.trim();
   if (forwardedHost) {
-    return normalizeHost(forwardedHost.split(",")[0]?.trim() ?? "");
+    return normalizePublicApiHostname(forwardedHost.split(",")[0]?.trim() ?? "");
   }
   const hostHeader = c.req.header("host")?.trim();
   if (hostHeader) {
-    return normalizeHost(hostHeader.split(":")[0]?.trim() ?? "");
+    return normalizePublicApiHostname(hostHeader);
   }
   return "";
 }
 
 function getProductionAllowedHosts(): Set<string> {
-  const hosts = new Set<string>([normalizeHost(CANONICAL_PRODUCTION_API_HOST)]);
-  const raw = process.env.PUBLIC_API_ALLOWED_HOSTS?.trim();
-  if (!raw) {
-    return hosts;
-  }
-  for (const part of raw.split(",")) {
-    const h = normalizeHost(part);
-    if (h) {
-      hosts.add(h);
-    }
-  }
-  return hosts;
+  return new Set(
+    resolvePublicApiAllowedHosts(process.env.API_URL, process.env.FRONTEND_URL),
+  );
 }
 
 export async function apiHostGuardMiddleware(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       APP_URL: http://backend:3001
       NODE_ENV: ${NODE_ENV:-production}
       FRONTEND_URL: ${FRONTEND_URL:-http://localhost:8080}
+      API_URL: ${API_URL:-}
       ALLOWED_PRODUCTION_ORIGINS: ${ALLOWED_PRODUCTION_ORIGINS:-}
       DATABASE_URL: postgresql://senqo:${DB_PASSWORD:-senqo}@postgres:5432/senqo
       JWT_SECRET: ${JWT_SECRET:-dev-secret-change-in-production}
@@ -68,6 +69,7 @@ services:
       context: ./frontend
       args:
         VITE_API_BASE_URL: ""
+        VITE_API_URL: ${API_URL:-${FRONTEND_URL:-}}
     restart: unless-stopped
     ports:
       - "${DEV_FRONTEND_PORT:-8080}:${FRONTEND_CONTAINER_PORT:-80}"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,6 +3,8 @@ WORKDIR /app
 
 ARG VITE_API_BASE_URL=http://backend:3001
 ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
+ARG VITE_API_URL=
+ENV VITE_API_URL=$VITE_API_URL
 
 COPY package.json package-lock.json* ./
 RUN npm ci

--- a/frontend/src/lib/public-tasks-api.test.ts
+++ b/frontend/src/lib/public-tasks-api.test.ts
@@ -1,30 +1,48 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  buildCreateTaskCurlExample,
-  buildCreateTaskRequestBody,
-  getPublicTasksApiUrl,
-} from "./public-tasks-api";
+
+async function loadPublicTasksApi() {
+  vi.resetModules();
+  return import("./public-tasks-api.js");
+}
 
 describe("getPublicTasksApiUrl", () => {
   afterEach(() => {
+    vi.unstubAllEnvs();
     vi.unstubAllGlobals();
+    vi.resetModules();
   });
 
-  // In production (app.senqo.app), the public tasks API URL must point to the dedicated api.senqo.app host.
-  it("returns production API host when app runs on senqo.app", () => {
+  // VITE_API_URL set → docs and curl examples use the configured public API host.
+  it("returns VITE_API_URL host when configured", async () => {
+    vi.stubEnv("VITE_API_URL", "https://demo-app.senqo.app");
     vi.stubGlobal("window", {
       location: {
-        hostname: "app.senqo.app",
+        hostname: "demo-app.senqo.app",
         protocol: "https:",
-        origin: "https://app.senqo.app",
+        origin: "https://demo-app.senqo.app",
       },
     });
-
-    expect(getPublicTasksApiUrl()).toBe("https://api.senqo.app/api/tasks");
+    const { getPublicTasksApiUrl } = await loadPublicTasksApi();
+    expect(getPublicTasksApiUrl()).toBe("https://demo-app.senqo.app/api/tasks");
   });
 
-  // In local dev (localhost), the URL must be same-origin so it works without CORS issues.
-  it("returns same-origin API path for local development", () => {
+  // VITE_API_URL unset → same-origin URL works for single-domain VPS deployments.
+  it("returns same-origin API path when VITE_API_URL is unset", async () => {
+    vi.stubEnv("VITE_API_URL", "");
+    vi.stubGlobal("window", {
+      location: {
+        hostname: "demo-app.senqo.app",
+        protocol: "https:",
+        origin: "https://demo-app.senqo.app",
+      },
+    });
+    const { getPublicTasksApiUrl } = await loadPublicTasksApi();
+    expect(getPublicTasksApiUrl()).toBe("https://demo-app.senqo.app/api/tasks");
+  });
+
+  // Local dev uses same-origin so examples work behind the Vite proxy without CORS.
+  it("returns same-origin API path for local development", async () => {
+    vi.stubEnv("VITE_API_URL", "");
     vi.stubGlobal("window", {
       location: {
         hostname: "localhost",
@@ -32,14 +50,15 @@ describe("getPublicTasksApiUrl", () => {
         origin: "http://localhost:5173",
       },
     });
-
+    const { getPublicTasksApiUrl } = await loadPublicTasksApi();
     expect(getPublicTasksApiUrl()).toBe("http://localhost:5173/api/tasks");
   });
 });
 
 describe("buildCreateTaskRequestBody", () => {
   // The request body must include all fields required by the API: message, sender, recipient, schedule type, timestamp, and timezone.
-  it("includes one_time schedule fields required by the API", () => {
+  it("includes one_time schedule fields required by the API", async () => {
+    const { buildCreateTaskRequestBody } = await loadPublicTasksApi();
     expect(
       buildCreateTaskRequestBody({
         message: "Ping",
@@ -60,8 +79,15 @@ describe("buildCreateTaskRequestBody", () => {
 });
 
 describe("buildCreateTaskCurlExample", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
   // The generated curl example must contain the resolved API URL, the API key header, and the scheduleType payload.
-  it("embeds the resolved URL and API key in a copy-ready curl command", () => {
+  it("embeds the resolved URL and API key in a copy-ready curl command", async () => {
+    vi.stubEnv("VITE_API_URL", "");
     vi.stubGlobal("window", {
       location: {
         hostname: "localhost",
@@ -69,7 +95,7 @@ describe("buildCreateTaskCurlExample", () => {
         origin: "http://localhost:5173",
       },
     });
-
+    const { buildCreateTaskCurlExample } = await loadPublicTasksApi();
     const curl = buildCreateTaskCurlExample({
       apiKey: "sk_test_key",
       scheduleAt: "2026-12-31T23:00:00",

--- a/frontend/src/lib/public-tasks-api.ts
+++ b/frontend/src/lib/public-tasks-api.ts
@@ -1,6 +1,3 @@
-const PRODUCTION_APP_DOMAIN = "senqo.app";
-const PRODUCTION_PUBLIC_API_HOST = "api.senqo.app";
-
 export type CreateTaskApiExampleInput = {
   apiKey?: string;
   message?: string;
@@ -11,18 +8,52 @@ export type CreateTaskApiExampleInput = {
   fileUrl?: string;
 };
 
-export function getPublicTasksApiUrl(): string {
-  if (typeof window === "undefined") {
-    return `https://${PRODUCTION_PUBLIC_API_HOST}/api/tasks`;
+function normalizeConfiguredApiHost(raw: string): string {
+  const trimmed = raw.trim().toLowerCase();
+  if (!trimmed) {
+    return "";
   }
 
-  const hostname = window.location.hostname.toLowerCase();
-  if (
-    hostname === PRODUCTION_APP_DOMAIN ||
-    hostname.endsWith(`.${PRODUCTION_APP_DOMAIN}`)
-  ) {
-    const protocol = window.location.protocol === "http:" ? "http:" : "https:";
-    return `${protocol}//${PRODUCTION_PUBLIC_API_HOST}/api/tasks`;
+  try {
+    if (trimmed.includes("://")) {
+      return new URL(trimmed).hostname;
+    }
+  } catch {
+    // Fall through to hostname-only parsing.
+  }
+
+  const withoutPort = trimmed.split(":")[0]?.trim() ?? "";
+  if (!withoutPort) {
+    return "";
+  }
+  return withoutPort.endsWith(".") ? withoutPort.slice(0, -1) : withoutPort;
+}
+
+function configuredPublicApiHost(): string | null {
+  const raw = (import.meta.env as Record<string, string | undefined>).VITE_API_URL?.trim();
+  if (!raw) {
+    return null;
+  }
+  const host = normalizeConfiguredApiHost(raw);
+  return host || null;
+}
+
+function publicApiProtocolForHost(host: string): "http:" | "https:" {
+  if (host === "localhost" || host.endsWith(".localhost")) {
+    return "http:";
+  }
+  return "https:";
+}
+
+export function getPublicTasksApiUrl(): string {
+  const configuredHost = configuredPublicApiHost();
+  if (configuredHost) {
+    const protocol = publicApiProtocolForHost(configuredHost);
+    return `${protocol}//${configuredHost}/api/tasks`;
+  }
+
+  if (typeof window === "undefined") {
+    return "https://localhost/api/tasks";
   }
 
   return `${window.location.origin}/api/tasks`;

--- a/frontend/src/pages/settings/components/api-keys-docs-data.ts
+++ b/frontend/src/pages/settings/components/api-keys-docs-data.ts
@@ -47,7 +47,7 @@ export const createTaskBodyParams = [
 export const createTaskErrorCodes = [
   { http: "401", error: "invalid_api_key", meaning: "API key missing or invalid." },
   { http: "401", error: "api_key_expired", meaning: "API key exists but expired." },
-  { http: "403", error: "forbidden_host", meaning: "Production requests must use api.senqo.app." },
+  { http: "403", error: "forbidden_host", meaning: "Production requests must use the configured API host (API_URL or FRONTEND_URL)." },
   { http: "400", error: "invalid_payload", meaning: "Body fields are missing or invalid." },
   { http: "400", error: "invalid_file_url", meaning: "fileUrl must be a public HTTPS URL." },
   { http: "422", error: "unsupported_schedule_type", meaning: "Only one_time is supported." },

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string;
+  readonly VITE_API_URL?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## What & why

Remove old hard coded api url to open up to other api url.

## Checklist

- [x] **User impact:** none
- [x] **Migration:** none
- [x] **Tests:** Test to check url validity
- [x] **README:** update readme

## How to verify

1. Api not bounded by just one api anymore
