### PR TITLE
Fix inbound AI using wrong WhatsApp connection with multiple lines

### DIFF
--- a/backend/src/lib/job-queue.ts
+++ b/backend/src/lib/job-queue.ts
@@ -11,6 +11,8 @@ export type InboundAiJobData = {
   workspaceId: string;
   conversationId: string;
   agentConfigId: string;
+  /** Line that received the inbound; omitted on jobs queued before multi-connection scoping. */
+  whatsappConnectionId?: string;
 };
 
 let boss: PgBoss | null = null;

--- a/backend/src/repositories/whatsapp.test.ts
+++ b/backend/src/repositories/whatsapp.test.ts
@@ -16,8 +16,25 @@ const mockDb = {
 
 vi.mock("../db/index.js", () => ({ db: mockDb }));
 
-const { createConnection, bindAgentToWhatsappConnection, updateConnectionMode, deleteConnectionByWorkspace } =
-  await vi.importActual("../repositories/whatsapp.js") as typeof import("../repositories/whatsapp.js");
+const {
+  createConnection,
+  bindAgentToWhatsappConnection,
+  updateConnectionMode,
+  deleteConnectionByWorkspace,
+  findOrCreateConversationByWhatsappChatId,
+  getWhatsappConnectionModeForInboundAi,
+} = await vi.importActual("../repositories/whatsapp.js") as typeof import("../repositories/whatsapp.js");
+
+function mockSelectLimitRows(rows: unknown[], options?: { orderBy?: boolean }) {
+  const mockLimit = vi.fn().mockResolvedValue(rows);
+  const mockWhereSelect = options?.orderBy
+    ? vi.fn().mockReturnValue({
+        orderBy: vi.fn().mockReturnValue({ limit: mockLimit }),
+      })
+    : vi.fn().mockReturnValue({ limit: mockLimit });
+  const mockFrom = vi.fn().mockReturnValue({ where: mockWhereSelect });
+  mockDb.select.mockReturnValueOnce({ from: mockFrom });
+}
 
 beforeEach(() => { vi.clearAllMocks(); });
 
@@ -69,6 +86,122 @@ describe("updateConnectionMode", () => {
     // @ts-expect-error - testing invalid mode input
     const result = await updateConnectionMode("ws-1", "conn-1", "invalid");
     expect(result.ok).toBe(false);
+  });
+});
+
+describe("getWhatsappConnectionModeForInboundAi", () => {
+  // Debounce job passes the line that received the inbound → testing mode is returned even when the thread row still points at an inactive line, needed to fix multi-connection AI gating.
+  it("returns preferred connection mode before the conversation row", async () => {
+    mockSelectLimitRows([
+      {
+        id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        mode: "testing",
+        status: "authorized",
+        agentConfigId: "agent-1",
+      },
+    ]);
+
+    const mode = await getWhatsappConnectionModeForInboundAi(
+      "ws-1",
+      "conv-1",
+      "agent-1",
+      "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    );
+
+    expect(mode).toBe("testing");
+    expect(mockDb.select).toHaveBeenCalledTimes(1);
+  });
+
+  // Thread row still references an inactive line and no preferred id was queued → inactive is returned, needed to keep inactive lines from running AI when scoping is missing.
+  it("returns inactive when conversation is scoped to an inactive line", async () => {
+    mockSelectLimitRows([{ whatsappConnectionId: "conn-inactive" }]);
+    mockSelectLimitRows([
+      {
+        id: "conn-inactive",
+        mode: "inactive",
+        status: "authorized",
+        agentConfigId: "agent-1",
+      },
+    ]);
+
+    const mode = await getWhatsappConnectionModeForInboundAi("ws-1", "conv-1", "agent-1");
+
+    expect(mode).toBe("inactive");
+  });
+
+  // Legacy thread has no connection id on the row → latest message metadata supplies the testing line, needed for older conversations before connection scoping was persisted.
+  it("falls back to message metadata when conversation connection id is missing", async () => {
+    mockSelectLimitRows([{ whatsappConnectionId: null }]);
+    mockSelectLimitRows(
+      [
+        {
+          metadata: {
+            whatsappConnectionId: "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+          },
+        },
+      ],
+      { orderBy: true },
+    );
+    mockSelectLimitRows([
+      {
+        id: "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+        mode: "testing",
+        status: "authorized",
+        agentConfigId: "agent-1",
+      },
+    ]);
+
+    const mode = await getWhatsappConnectionModeForInboundAi("ws-1", "conv-1", "agent-1");
+
+    expect(mode).toBe("testing");
+  });
+});
+
+describe("findOrCreateConversationByWhatsappChatId", () => {
+  // Existing thread was opened on another line → whatsapp_connection_id is updated to the inbound line, needed so multi-connection workspaces gate AI on the active line.
+  it("updates whatsapp_connection_id when reusing an existing conversation on a different line", async () => {
+    const mockLimit = vi.fn().mockResolvedValue([
+      { id: "conv-1", whatsappConnectionId: "conn-inactive" },
+    ]);
+    const mockWhereSelect = vi.fn().mockReturnValue({ limit: mockLimit });
+    const mockFrom = vi.fn().mockReturnValue({ where: mockWhereSelect });
+    mockDb.select.mockReturnValue({ from: mockFrom });
+    mockSet.mockReturnValue({
+      where: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const conversationId = await findOrCreateConversationByWhatsappChatId(
+      "ws-1",
+      "conn-testing",
+      "contact-1",
+      "Test User",
+      "60123456789@s.whatsapp.net",
+    );
+
+    expect(conversationId).toBe("conv-1");
+    expect(mockDb.update).toHaveBeenCalled();
+    expect(mockSet).toHaveBeenCalledWith({ whatsappConnectionId: "conn-testing" });
+  });
+
+  // Thread already belongs to the inbound line → no redundant update is issued, needed to avoid needless writes on every message.
+  it("does not update whatsapp_connection_id when the line already matches", async () => {
+    const mockLimit = vi.fn().mockResolvedValue([
+      { id: "conv-1", whatsappConnectionId: "conn-testing" },
+    ]);
+    const mockWhereSelect = vi.fn().mockReturnValue({ limit: mockLimit });
+    const mockFrom = vi.fn().mockReturnValue({ where: mockWhereSelect });
+    mockDb.select.mockReturnValue({ from: mockFrom });
+
+    const conversationId = await findOrCreateConversationByWhatsappChatId(
+      "ws-1",
+      "conn-testing",
+      "contact-1",
+      "Test User",
+      "60123456789@s.whatsapp.net",
+    );
+
+    expect(conversationId).toBe("conv-1");
+    expect(mockDb.update).not.toHaveBeenCalled();
   });
 });
 

--- a/backend/src/repositories/whatsapp.ts
+++ b/backend/src/repositories/whatsapp.ts
@@ -996,14 +996,78 @@ export async function resolveWhatsappConnectionForConversationAgentOutbound(
   }
 }
 
-/** Connection mode for inbound AI gating: prefers the thread's line when `whatsapp_connection_id` is set. */
+const WHATSAPP_CONNECTION_ID_IN_METADATA_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Latest inbound/outbound line on the thread from message metadata (legacy rows). */
+async function getLatestWhatsappConnectionIdFromMessageMetadata(
+  workspaceId: string,
+  conversationId: string,
+): Promise<string | null> {
+  try {
+    const rows = await db
+      .select({ metadata: messages.metadata })
+      .from(messages)
+      .where(
+        and(
+          eq(messages.workspaceId, workspaceId),
+          eq(messages.conversationId, conversationId),
+        ),
+      )
+      .orderBy(desc(messages.createdAt))
+      .limit(250);
+
+    for (const row of rows) {
+      const meta = row.metadata as Record<string, unknown> | null;
+      if (!meta || typeof meta !== "object") continue;
+      const raw = meta.whatsappConnectionId;
+      const idStr = typeof raw === "string" ? raw.trim() : "";
+      if (idStr && WHATSAPP_CONNECTION_ID_IN_METADATA_RE.test(idStr)) {
+        return idStr;
+      }
+    }
+    return null;
+  } catch (error) {
+    console.error(
+      `[${scope}/getLatestWhatsappConnectionIdFromMessageMetadata] Unexpected error: ${String(error)}`,
+    );
+    return null;
+  }
+}
+
+async function resolveWhatsappConnectionModeById(
+  workspaceId: string,
+  connectionId: string,
+): Promise<WhatsappConnectionMode | null> {
+  const trimmedId = connectionId.trim();
+  if (!trimmedId) return null;
+  const row = await getWhatsappConnectionRowById(workspaceId, trimmedId);
+  return row?.mode ?? null;
+}
+
+/**
+ * Connection mode for inbound AI gating.
+ * Prefers the line that received the message, then the thread row, then recent message metadata.
+ */
 export async function getWhatsappConnectionModeForInboundAi(
   workspaceId: string,
   conversationId: string,
   agentConfigId: string,
+  preferredWhatsappConnectionId?: string,
 ): Promise<WhatsappConnectionMode> {
   const trimmedAgent = agentConfigId.trim();
   try {
+    const preferredId = preferredWhatsappConnectionId?.trim() ?? "";
+    if (preferredId.length > 0) {
+      const preferredMode = await resolveWhatsappConnectionModeById(workspaceId, preferredId);
+      if (preferredMode) {
+        console.info(
+          `[${scope}/getWhatsappConnectionModeForInboundAi] Success: preferred userId=${workspaceId}`,
+        );
+        return preferredMode;
+      }
+    }
+
     const convData = await db
       .select({ whatsappConnectionId: conversations.whatsappConnectionId })
       .from(conversations)
@@ -1021,10 +1085,27 @@ export async function getWhatsappConnectionModeForInboundAi(
         ? conv.whatsappConnectionId.trim()
         : "";
     if (scopedId.length > 0) {
-      const row = await getWhatsappConnectionRowById(workspaceId, scopedId);
-      if (row) {
+      const scopedMode = await resolveWhatsappConnectionModeById(workspaceId, scopedId);
+      if (scopedMode) {
         console.info(`[${scope}/getWhatsappConnectionModeForInboundAi] Success: scoped userId=${workspaceId}`);
-        return row.mode;
+        return scopedMode;
+      }
+    }
+
+    const metadataConnectionId = await getLatestWhatsappConnectionIdFromMessageMetadata(
+      workspaceId,
+      conversationId,
+    );
+    if (metadataConnectionId) {
+      const metadataMode = await resolveWhatsappConnectionModeById(
+        workspaceId,
+        metadataConnectionId,
+      );
+      if (metadataMode) {
+        console.info(
+          `[${scope}/getWhatsappConnectionModeForInboundAi] Success: metadata userId=${workspaceId}`,
+        );
+        return metadataMode;
       }
     }
 
@@ -1132,8 +1213,12 @@ export async function findOrCreateConversationByWhatsappChatId(
 ): Promise<string | null> {
   try {
     const title = `${contactDisplayName} - WhatsApp`;
+    const incomingConnectionId = whatsappConnectionId.trim();
     const existing = await db
-      .select({ id: conversations.id })
+      .select({
+        id: conversations.id,
+        whatsappConnectionId: conversations.whatsappConnectionId,
+      })
       .from(conversations)
       .where(
         and(
@@ -1145,6 +1230,21 @@ export async function findOrCreateConversationByWhatsappChatId(
     const existingRow = existing[0] ?? null;
 
     if (existingRow?.id) {
+      const currentConnectionId = existingRow.whatsappConnectionId?.trim() ?? "";
+      if (
+        incomingConnectionId.length > 0 &&
+        currentConnectionId !== incomingConnectionId
+      ) {
+        await db
+          .update(conversations)
+          .set({ whatsappConnectionId: incomingConnectionId })
+          .where(
+            and(
+              eq(conversations.workspaceId, workspaceId),
+              eq(conversations.id, existingRow.id),
+            ),
+          );
+      }
       console.info(`[${scope}/findOrCreateConversationByWhatsappChatId] Success: userId=${workspaceId}`);
       return existingRow.id;
     }

--- a/backend/src/routes/whatsapp.ts
+++ b/backend/src/routes/whatsapp.ts
@@ -611,6 +611,7 @@ async function handleIncomingMessageReceived(
         workspaceId: input.connection.workspace_id,
         conversationId,
         agentConfigId: input.connection.agent_config_id,
+        whatsappConnectionId: input.connection.id,
       });
     } else {
       const skipReason =

--- a/backend/src/services/inbound-ai-debounce-run.test.ts
+++ b/backend/src/services/inbound-ai-debounce-run.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockRunAgentSession = vi.fn();
+const mockGetConversationHandlingMode = vi.fn();
+const mockListConversationMessagesBareForAi = vi.fn();
+const mockGetContactIsTestForConversation = vi.fn();
+const mockGetWhatsappConnectionModeForInboundAi = vi.fn();
+const mockClearInboundAiDebouncePending = vi.fn();
+
+vi.mock("../agent/agent.js", () => ({
+  runAgentSession: mockRunAgentSession,
+}));
+
+vi.mock("../repositories/conversations.js", () => ({
+  getConversationHandlingMode: mockGetConversationHandlingMode,
+  listConversationMessagesBareForAi: mockListConversationMessagesBareForAi,
+  updateConversationHandlingMode: vi.fn(),
+}));
+
+vi.mock("../repositories/contacts.js", () => ({
+  getContactIsTestForConversation: mockGetContactIsTestForConversation,
+}));
+
+vi.mock("../repositories/inbound-ai-debounce-pending.js", () => ({
+  clearInboundAiDebouncePending: mockClearInboundAiDebouncePending,
+}));
+
+vi.mock("../repositories/whatsapp.js", () => ({
+  createConversationMessage: vi.fn(),
+  getWhatsappConnectionModeForInboundAi: mockGetWhatsappConnectionModeForInboundAi,
+}));
+
+vi.mock("../lib/inbound-media-resolve.js", () => ({
+  resolveInboundMediaSigned: vi.fn(),
+}));
+
+const { executeInboundDebouncedAiRun } = await import("./inbound-ai-debounce-run.js");
+
+const baseInput = {
+  workspaceId: "ws-1",
+  conversationId: "conv-1",
+  agentConfigId: "agent-1",
+  whatsappConnectionId: "conn-testing",
+};
+
+function mockTrailingUserMessage(content = "hello") {
+  mockListConversationMessagesBareForAi.mockResolvedValue([
+    {
+      role: "user",
+      content,
+      created_at: "2026-06-11T10:00:00.000Z",
+    },
+  ]);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetConversationHandlingMode.mockResolvedValue("ai");
+  mockGetContactIsTestForConversation.mockResolvedValue(true);
+  mockRunAgentSession.mockResolvedValue({
+    sessionId: "conv-1",
+    reply: "Hi there",
+    num_whatsapp_send: 0,
+    modelMessages: [],
+    reasoningForOperators: "",
+  });
+  mockClearInboundAiDebouncePending.mockResolvedValue(true);
+});
+
+describe("executeInboundDebouncedAiRun", () => {
+  // Debounce job carries the testing line that received the inbound → mode lookup uses that line and AI inference runs, needed to verify the multi-connection fix end-to-end in the debounced path.
+  it("runs AI when the debounce job scopes to a testing line and test contact", async () => {
+    mockGetWhatsappConnectionModeForInboundAi.mockResolvedValue("testing");
+    mockTrailingUserMessage();
+
+    const result = await executeInboundDebouncedAiRun(baseInput);
+
+    expect(result.ok).toBe(true);
+    expect(mockGetWhatsappConnectionModeForInboundAi).toHaveBeenCalledWith(
+      "ws-1",
+      "conv-1",
+      "agent-1",
+      "conn-testing",
+    );
+    expect(mockRunAgentSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skipInference: false,
+        skipInferenceReason: undefined,
+      }),
+    );
+  });
+
+  // Resolved mode is inactive (stale thread line) → inbound is saved but inference is skipped with the inactive reason, matching the operator-visible failure mode.
+  it("skips inference when resolved connection mode is inactive", async () => {
+    mockGetWhatsappConnectionModeForInboundAi.mockResolvedValue("inactive");
+    mockTrailingUserMessage();
+
+    const result = await executeInboundDebouncedAiRun({
+      ...baseInput,
+      whatsappConnectionId: undefined,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(mockRunAgentSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skipInference: true,
+        skipInferenceReason: "connection mode is inactive",
+      }),
+    );
+  });
+});

--- a/backend/src/services/inbound-ai-debounce-run.ts
+++ b/backend/src/services/inbound-ai-debounce-run.ts
@@ -34,6 +34,7 @@ export type InboundDebouncedRunInput = {
   workspaceId: string;
   conversationId: string;
   agentConfigId: string;
+  whatsappConnectionId?: string;
 };
 
 /**
@@ -51,6 +52,7 @@ export async function executeInboundDebouncedAiRun(input: InboundDebouncedRunInp
       input.workspaceId,
       input.conversationId,
       input.agentConfigId,
+      input.whatsappConnectionId,
     ),
   );
   const normalizedHandling = handlingMode ?? "ai";

--- a/backend/src/services/inbound-ai-debounce-schedule.test.ts
+++ b/backend/src/services/inbound-ai-debounce-schedule.test.ts
@@ -12,6 +12,7 @@ const input = {
   workspaceId: "ws-1",
   conversationId: "conv-1",
   agentConfigId: "agent-1",
+  whatsappConnectionId: "conn-testing-1",
 };
 
 beforeEach(() => {

--- a/backend/src/services/inbound-ai-debounce-schedule.ts
+++ b/backend/src/services/inbound-ai-debounce-schedule.ts
@@ -6,6 +6,7 @@ export async function scheduleInboundAiDebounced(input: {
   workspaceId: string;
   conversationId: string;
   agentConfigId: string;
+  whatsappConnectionId: string;
 }): Promise<void> {
   await scheduleInboundAiDebouncedJob(input);
 }

--- a/backend/src/services/job-scheduler.test.ts
+++ b/backend/src/services/job-scheduler.test.ts
@@ -78,6 +78,7 @@ describe("scheduleInboundAiDebouncedJob", () => {
       workspaceId: "ws-1",
       conversationId: "conv-1",
       agentConfigId: "agent-1",
+      whatsappConnectionId: "conn-testing-1",
     });
 
     expect(mockCancel).toHaveBeenCalledWith("inbound-ai", "job-old-1");

--- a/backend/src/services/job-scheduler.ts
+++ b/backend/src/services/job-scheduler.ts
@@ -30,6 +30,7 @@ export type ScheduleInboundAiDebouncedInput = {
   workspaceId: string;
   conversationId: string;
   agentConfigId: string;
+  whatsappConnectionId: string;
 };
 
 function buildTaskExecutePayload(input: ScheduleAgentTaskInput): TaskExecutePayload {
@@ -112,6 +113,7 @@ export async function scheduleInboundAiDebouncedJob(
     workspaceId: input.workspaceId,
     conversationId: input.conversationId,
     agentConfigId: input.agentConfigId,
+    whatsappConnectionId: input.whatsappConnectionId,
   };
 
   try {


### PR DESCRIPTION
## Summary
- Scope inbound AI debounce jobs to the WhatsApp connection that received the message, instead of re-resolving mode from a stale conversation row or arbitrary agent fallback.
- Sync `whatsapp_connection_id` when reusing an existing conversation on a different line, and fall back to recent message metadata for legacy threads.
- Add repository and debounce-run tests covering preferred-line resolution, metadata fallback, and skip/run inference behavior.

## Test plan
- [x] `npm run test` in `backend/` (181 tests pass)
- [ ] Connect two WhatsApp lines (one inactive, one testing) to the same agent
- [ ] Message from a test contact on the testing line → agent replies after debounce
- [ ] Confirm logs no longer show `connection mode is inactive` for that flow


Made with [Cursor](https://cursor.com)